### PR TITLE
v-get: Use modern JS syntax

### DIFF
--- a/htmlbars-plugins/v-get.js
+++ b/htmlbars-plugins/v-get.js
@@ -110,8 +110,7 @@ class VGet {
    */
   processNodeParams(node) {
     if (node.params) {
-      for (let i = 0; i < node.params.length; i++) {
-        let param = node.params[i];
+      for (let param of node.params) {
         if (param.type === 'SubExpression') {
           if (param.path.original === 'v-get') {
             this.transformToGet(param);
@@ -129,8 +128,7 @@ class VGet {
    */
   processNodeHash(node) {
     if (node.hash && node.hash.pairs) {
-      for (let i = 0; i < node.hash.pairs.length; i++) {
-        let pair = node.hash.pairs[i];
+      for (let pair of node.hash.pairs) {
         if (pair.value.type === 'SubExpression') {
           if (pair.value.path.original === 'v-get') {
             this.transformToGet(pair.value);
@@ -148,17 +146,15 @@ class VGet {
    * @param  {AST.Node} node
    */
   processNodeAttributes(node) {
-    let i;
     if (node.attributes) {
-      for (i = 0; i < node.attributes.length; i++) {
-        let attr = node.attributes[i];
+      for (let attr of node.attributes) {
         this.processNode(attr.value);
       }
     }
 
     if (node.parts) {
-      for (i = 0; i < node.parts.length; i++) {
-        this.processNode(node.parts[i]);
+      for (let part of node.parts) {
+        this.processNode(part);
       }
     }
   }

--- a/htmlbars-plugins/v-get.js
+++ b/htmlbars-plugins/v-get.js
@@ -70,8 +70,8 @@ class VGet {
   }
 
   transform(ast) {
-    var context = this;
-    var walker = new this.syntax.Walker();
+    let context = this;
+    let walker = new this.syntax.Walker();
 
     walker.visit(ast, function(node) {
       if (context.validate(node)) {
@@ -91,7 +91,7 @@ class VGet {
   }
 
   processNode(node) {
-    var type = node.type;
+    let type = node.type;
     node = unwrapNode(node);
 
     // {{v-get model 'username' 'isValid'}}
@@ -110,8 +110,8 @@ class VGet {
    */
   processNodeParams(node) {
     if (node.params) {
-      for (var i = 0; i < node.params.length; i++) {
-        var param = node.params[i];
+      for (let i = 0; i < node.params.length; i++) {
+        let param = node.params[i];
         if (param.type === 'SubExpression') {
           if (param.path.original === 'v-get') {
             this.transformToGet(param);
@@ -129,8 +129,8 @@ class VGet {
    */
   processNodeHash(node) {
     if (node.hash && node.hash.pairs) {
-      for (var i = 0; i < node.hash.pairs.length; i++) {
-        var pair = node.hash.pairs[i];
+      for (let i = 0; i < node.hash.pairs.length; i++) {
+        let pair = node.hash.pairs[i];
         if (pair.value.type === 'SubExpression') {
           if (pair.value.path.original === 'v-get') {
             this.transformToGet(pair.value);
@@ -148,10 +148,10 @@ class VGet {
    * @param  {AST.Node} node
    */
   processNodeAttributes(node) {
-    var i;
+    let i;
     if (node.attributes) {
       for (i = 0; i < node.attributes.length; i++) {
-        var attr = node.attributes[i];
+        let attr = node.attributes[i];
         this.processNode(attr.value);
       }
     }
@@ -173,8 +173,8 @@ class VGet {
    */
   transformToGet(node) {
     node = unwrapNode(node);
-    var params = node.params;
-    var numParams = params.length;
+    let params = node.params;
+    let numParams = params.length;
 
     if (numParams < 2) {
       throw new Error('{{v-get}} requires at least two arguments');
@@ -184,7 +184,7 @@ class VGet {
     }
 
     // (get model 'validations')
-    var root = this.syntax.builders.sexpr(this.syntax.builders.path('get'), [
+    let root = this.syntax.builders.sexpr(this.syntax.builders.path('get'), [
       params[0],
       this.syntax.builders.string('validations')
     ]);

--- a/htmlbars-plugins/v-get.js
+++ b/htmlbars-plugins/v-get.js
@@ -83,10 +83,8 @@ class VGet {
   }
 
   validate(node) {
-    return (
-      ['BlockStatement', 'MustacheStatement', 'ElementNode'].indexOf(
-        node.type
-      ) > -1
+    return ['BlockStatement', 'MustacheStatement', 'ElementNode'].includes(
+      node.type
     );
   }
 


### PR DESCRIPTION
This PR updates the `v-get` compiler plugin to use modern JS syntax. The addon already declares Node.js 10 as the minimum version, which supports all of these new features.