### PR TITLE
Remove ember-require-module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
-    "ember-require-module": "^0.3.0",
     "ember-validators": "^3.0.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Dropping the [ember-require-module](https://github.com/offirgolan/ember-require-module) dependency as it's not needed anymore.