### PR TITLE
Fix lint issues for JS files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-/*
 # unconventional js
 /blueprints/*/files/
 /blueprints/**/*files/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,11 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {},
+  rules: {
+    'ember/no-classic-classes': 'off',
+    'ember/no-new-mixins': 'off',
+    'ember/no-volatile-computed-properties': 'off',
+  },
   overrides: [
     // node files
     {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-/*
 # unconventional js
 /blueprints/*/files/
 /vendor/

--- a/addon/-private/ember-internals.js
+++ b/addon/-private/ember-internals.js
@@ -4,9 +4,11 @@ import { A } from '@ember/array';
 let __EMBER_METAL__;
 let emberMetalPaths = [
   '@ember/-internals/metal', // ember-source from 3.10
-  '@ember/-internals/metal/index' // ember-source from 3.13
+  '@ember/-internals/metal/index', // ember-source from 3.13
 ];
-let metalPath = A(emberMetalPaths).find(path => Ember.__loader.registry[path]);
+let metalPath = A(emberMetalPaths).find(
+  (path) => Ember.__loader.registry[path]
+);
 if (metalPath) {
   __EMBER_METAL__ = Ember.__loader.require(metalPath);
 }

--- a/addon/-private/ember-validator.js
+++ b/addon/-private/ember-validator.js
@@ -3,7 +3,7 @@ import { validate as _validate } from 'ember-validators';
 
 export default Base.extend({
   validate() {
-    let result = _validate(this.get('_evType'), ...arguments);
+    let result = _validate(this._evType, ...arguments);
 
     if (result && typeof result === 'object') {
       return result.message
@@ -12,5 +12,5 @@ export default Base.extend({
     }
 
     return result;
-  }
+  },
 });

--- a/addon/-private/internal-result-object.js
+++ b/addon/-private/internal-result-object.js
@@ -1,4 +1,4 @@
-import EmberObject, { computed, set, get } from '@ember/object';
+import EmberObject, { computed, set } from '@ember/object';
 import { and, not, readOnly } from '@ember/object/computed';
 import { isNone } from '@ember/utils';
 import { makeArray } from '@ember/array';
@@ -20,7 +20,7 @@ export default EmberObject.extend({
   init() {
     this._super(...arguments);
 
-    if (this.get('isAsync')) {
+    if (this.isAsync) {
       this._handlePromise();
     }
   },
@@ -31,45 +31,26 @@ export default EmberObject.extend({
   isTruelyValid: and('isNotValidating', 'isValid'),
   isTruelyInvalid: and('isNotValidating', 'isInvalid'),
 
-  isAsync: computed('_promise', function() {
-    return isPromise(get(this, '_promise'));
+  isAsync: computed('_promise', function () {
+    return isPromise(this._promise);
   }),
 
-  messages: computed('message', function() {
-    return makeArray(get(this, 'message'));
+  messages: computed('message', function () {
+    return makeArray(this.message);
   }),
 
-  error: computed('isInvalid', 'type', 'message', 'attribute', function() {
-    if (get(this, 'isInvalid')) {
-      return ValidationError.create({
-        type: get(this, '_type'),
-        message: get(this, 'message'),
-        attribute: get(this, 'attribute')
-      });
-    }
-
-    return null;
-  }),
-
-  errors: computed('error', function() {
-    return makeArray(get(this, 'error'));
-  }),
-
-  warningMessages: computed('warningMessage', function() {
-    return makeArray(get(this, 'warningMessage'));
-  }),
-
-  warning: computed(
-    'isWarning',
-    'type',
-    'warningMessage',
+  error: computed(
+    '_type',
     'attribute',
-    function() {
-      if (get(this, 'isWarning') && !isNone(get(this, 'warningMessage'))) {
+    'isInvalid',
+    'message',
+    'type',
+    function () {
+      if (this.isInvalid) {
         return ValidationError.create({
-          type: get(this, '_type'),
-          message: get(this, 'warningMessage'),
-          attribute: get(this, 'attribute')
+          type: this._type,
+          message: this.message,
+          attribute: this.attribute,
         });
       }
 
@@ -77,15 +58,42 @@ export default EmberObject.extend({
     }
   ),
 
-  warnings: computed('warning', function() {
-    return makeArray(get(this, 'warning'));
+  errors: computed('error', function () {
+    return makeArray(this.error);
+  }),
+
+  warningMessages: computed('warningMessage', function () {
+    return makeArray(this.warningMessage);
+  }),
+
+  warning: computed(
+    '_type',
+    'attribute',
+    'isWarning',
+    'type',
+    'warningMessage',
+    function () {
+      if (this.isWarning && !isNone(this.warningMessage)) {
+        return ValidationError.create({
+          type: this._type,
+          message: this.warningMessage,
+          attribute: this.attribute,
+        });
+      }
+
+      return null;
+    }
+  ),
+
+  warnings: computed('warning', function () {
+    return makeArray(this.warning);
   }),
 
   _handlePromise() {
     set(this, 'isValidating', true);
 
-    get(this, '_promise').finally(() => {
+    this._promise.finally(() => {
       set(this, 'isValidating', false);
     });
-  }
+  },
 });

--- a/addon/-private/options.js
+++ b/addon/-private/options.js
@@ -10,7 +10,7 @@ const OptionsObject = EmberObject.extend({
       obj[key] = get(this, key);
       return obj;
     }, {});
-  }
+  },
 });
 
 export default class Options {
@@ -19,7 +19,7 @@ export default class Options {
     const createParams = { [OPTION_KEYS]: optionKeys, model, attribute };
 
     // If any of the options is a CP, we need to create a custom class for it
-    if (optionKeys.some(key => isDescriptor(options[key]))) {
+    if (optionKeys.some((key) => isDescriptor(options[key]))) {
       return OptionsObject.extend(options).create(createParams);
     }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -304,5 +304,5 @@ export const validator = Validator;
 
 export default {
   buildValidations,
-  validator
+  validator,
 };

--- a/addon/utils/array.js
+++ b/addon/utils/array.js
@@ -3,7 +3,7 @@ import { A as emberArray } from '@ember/array';
 const A = emberArray();
 
 export function callable(method) {
-  return function(collection) {
+  return function (collection) {
     return A[method].apply(collection, arguments);
   };
 }

--- a/addon/utils/cycle-breaker.js
+++ b/addon/utils/cycle-breaker.js
@@ -10,7 +10,7 @@ import MetaData from './meta-data';
 export default function cycleBreaker(fn, value) {
   let key = MetaData.symbol('cycle');
 
-  return function() {
+  return function () {
     if (MetaData.getData(this, key)) {
       return value;
     }

--- a/addon/utils/lookup-validator.js
+++ b/addon/utils/lookup-validator.js
@@ -13,9 +13,10 @@ export default function lookupValidator(owner, type) {
     );
   }
 
-  const validatorClass = owner.factoryFor === 'function'
-    ? owner.factoryFor(`validator:${type}`)
-    : owner.resolveRegistration(`validator:${type}`);
+  const validatorClass =
+    owner.factoryFor === 'function'
+      ? owner.factoryFor(`validator:${type}`)
+      : owner.resolveRegistration(`validator:${type}`);
 
   if (!validatorClass) {
     throw new Error(

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -2,10 +2,11 @@ import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
 import { assign } from '@ember/polyfills';
 import { isHTMLSafe } from '@ember/template';
-import EmberObject, { get } from '@ember/object';
+import EmberObject from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { A as emberArray, isArray } from '@ember/array';
-import DS from 'ember-data';
+import Model from '@ember-data/model';
+import { ManyArray, PromiseManyArray } from '@ember-data/model/-private';
 
 import Ember from 'ember';
 
@@ -22,7 +23,7 @@ export function unwrapString(s) {
 }
 
 export function unwrapProxy(o) {
-  return isProxy(o) ? unwrapProxy(get(o, 'content')) : o;
+  return isProxy(o) ? unwrapProxy(o.content) : o;
 }
 
 export function isProxy(o) {
@@ -34,15 +35,14 @@ export function isPromise(p) {
 }
 
 export function isDsModel(o) {
-  return !!(DS && o && o instanceof DS.Model);
+  return !!(o && o instanceof Model);
 }
 
 export function isDSManyArray(o) {
   return !!(
-    DS &&
     o &&
     isArray(o) &&
-    (o instanceof DS.PromiseManyArray || o instanceof DS.ManyArray)
+    (o instanceof PromiseManyArray || o instanceof ManyArray)
   );
 }
 
@@ -56,7 +56,7 @@ export function isObject(o) {
 
 export function isValidatable(value) {
   let v = unwrapProxy(value);
-  return isDsModel(v) ? !get(v, 'isDeleted') : true;
+  return isDsModel(v) ? !v.isDeleted : true;
 }
 
 export function getValidatableValue(value) {
@@ -65,7 +65,7 @@ export function getValidatableValue(value) {
   }
 
   if (isDSManyArray(value)) {
-    return emberArray(value.filter(v => isValidatable(v)));
+    return emberArray(value.filter((v) => isValidatable(v)));
   }
 
   return isValidatable(value) ? value : undefined;

--- a/addon/validations/error.js
+++ b/addon/validations/error.js
@@ -32,5 +32,5 @@ export default EmberObject.extend({
    * @property parentAttribute
    * @type {String}
    */
-  parentAttribute: null
+  parentAttribute: null,
 });

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -13,7 +13,7 @@ import { flatten, uniq, compact } from '../utils/array';
 function isAny(collection, key, value, defaultValue) {
   return computed(
     `${collection}.@each.${key}`,
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return get(this, collection).isAny(key, value);
     }, defaultValue)
   );
@@ -22,7 +22,7 @@ function isAny(collection, key, value, defaultValue) {
 function isEvery(collection, key, value, defaultValue) {
   return computed(
     `${collection}.@each.${key}`,
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return get(this, collection).isEvery(key, value);
     }, defaultValue)
   );
@@ -153,7 +153,7 @@ export default ArrayProxy.extend({
    */
   messages: computed(
     'content.@each.messages',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return uniq(compact(flatten(this.getEach('messages'))));
     })
   ).readOnly(),
@@ -203,7 +203,7 @@ export default ArrayProxy.extend({
    */
   warningMessages: computed(
     'content.@each.warningMessages',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return uniq(compact(flatten(this.getEach('warningMessages'))));
     })
   ).readOnly(),
@@ -240,7 +240,7 @@ export default ArrayProxy.extend({
   warnings: computed(
     'attribute',
     'content.@each.warnings',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return this._computeErrorCollection(this.getEach('warnings'));
     })
   ).readOnly(),
@@ -277,7 +277,7 @@ export default ArrayProxy.extend({
   errors: computed(
     'attribute',
     'content.@each.errors',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return this._computeErrorCollection(this.getEach('errors'));
     })
   ).readOnly(),
@@ -329,7 +329,7 @@ export default ArrayProxy.extend({
    * @readOnly
    * @type {Object}
    */
-  options: computed('_contentValidators.@each.options', function() {
+  options: computed('_contentValidators.@each.options', function () {
     return this._groupValidatorOptions(get(this, '_contentValidators'));
   }).readOnly(),
 
@@ -342,12 +342,12 @@ export default ArrayProxy.extend({
   _promise: computed(
     'content.@each._promise',
     '_contentResults.@each._promise',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return RSVP.allSettled(
         compact(
           flatten([
             this.get('_contentResults').getEach('_promise'),
-            this.getEach('_promise')
+            this.getEach('_promise'),
           ])
         )
       );
@@ -359,7 +359,7 @@ export default ArrayProxy.extend({
    * @type {Array}
    * @private
    */
-  _contentResults: computed('content.@each._result', function() {
+  _contentResults: computed('content.@each._result', function () {
     return emberArray(compact(this.getEach('_result')));
   }).readOnly(),
 
@@ -374,7 +374,7 @@ export default ArrayProxy.extend({
     let attribute = get(this, 'attribute');
     let errors = uniq(compact(flatten(collection)));
 
-    errors.forEach(e => {
+    errors.forEach((e) => {
       if (attribute && e.get('attribute') !== attribute) {
         e.set('parentAttribute', attribute);
       }
@@ -407,5 +407,5 @@ export default ArrayProxy.extend({
       }
       return options;
     }, {});
-  }
+  },
 });

--- a/addon/validations/validator.js
+++ b/addon/validations/validator.js
@@ -205,9 +205,9 @@ import { deprecate } from '@ember/debug';
  * @submodule Common Options
  */
 
-export default function(arg1, options) {
+export default function (arg1, options) {
   let props = {
-    options: isNone(options) ? {} : options
+    options: isNone(options) ? {} : options,
   };
 
   if (typeof arg1 === 'function') {

--- a/addon/validations/warning-result-collection.js
+++ b/addon/validations/warning-result-collection.js
@@ -5,15 +5,21 @@ import cycleBreaker from '../utils/cycle-breaker';
 import { flatten, uniq, compact } from '../utils/array';
 
 export default ResultCollection.extend({
-  isValid: computed(() => true).readOnly(),
+  isValid: computed(function () {
+    return true;
+  }).readOnly(),
   isTruelyValid: not('isValidating').readOnly(),
 
-  messages: computed(() => []).readOnly(),
-  errors: computed(() => []).readOnly(),
+  messages: computed(function () {
+    return [];
+  }).readOnly(),
+  errors: computed(function () {
+    return [];
+  }).readOnly(),
 
   warningMessages: computed(
     'content.@each.{messages,warningMessages}',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return uniq(
         compact(
           flatten([this.getEach('messages'), this.getEach('warningMessages')])
@@ -25,10 +31,10 @@ export default ResultCollection.extend({
   warnings: computed(
     'attribute',
     'content.@each.{errors,warnings}',
-    cycleBreaker(function() {
+    cycleBreaker(function () {
       return this._computeErrorCollection(
         flatten([this.getEach('errors'), this.getEach('warnings')])
       );
     })
-  ).readOnly()
+  ).readOnly(),
 });

--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 
 import { isPresent } from '@ember/utils';
-import { getProperties, get } from '@ember/object';
+import { get } from '@ember/object';
 import Base from 'ember-cp-validations/validators/base';
 
 /**
@@ -47,7 +47,7 @@ const Alias = Base.extend({
 
     if (typeof options === 'string') {
       opts = {
-        alias: options
+        alias: options,
       };
     }
     return this._super(opts, defaultOptions, globalOptions);
@@ -64,10 +64,7 @@ const Alias = Base.extend({
    * @param {String} attribute
    */
   validate(value, options, model, attribute) {
-    let { alias, firstMessageOnly } = getProperties(options, [
-      'alias',
-      'firstMessageOnly'
-    ]);
+    let { alias, firstMessageOnly } = options ?? {};
 
     assert(
       `[validator:alias] [${attribute}] option 'alias' is required`,
@@ -76,15 +73,13 @@ const Alias = Base.extend({
 
     let aliasValidation = get(model, `validations.attrs.${alias}`);
 
-    return firstMessageOnly
-      ? get(aliasValidation, 'message')
-      : get(aliasValidation, 'content');
-  }
+    return firstMessageOnly ? aliasValidation.message : aliasValidation.content;
+  },
 });
 
 Alias.reopenClass({
   getDependentsFor(attribute, options) {
-    let alias = typeof options === 'string' ? options : get(options, 'alias');
+    let alias = typeof options === 'string' ? options : options.alias;
 
     assert(
       `[validator:alias] [${attribute}] 'alias' must be a string`,
@@ -92,7 +87,7 @@ Alias.reopenClass({
     );
 
     return [`${alias}.messages.[]`, `${alias}.isTruelyValid`];
-  }
+  },
 });
 
 export default Alias;

--- a/addon/validators/belongs-to.js
+++ b/addon/validators/belongs-to.js
@@ -1,4 +1,3 @@
-import { get } from '@ember/object';
 import Base from 'ember-cp-validations/validators/base';
 import { isPromise } from 'ember-cp-validations/utils/utils';
 
@@ -75,14 +74,14 @@ const BelongsTo = Base.extend({
   validate(value, ...args) {
     if (value) {
       if (isPromise(value)) {
-        return value.then(model => this.validate(model, ...args));
+        return value.then((model) => this.validate(model, ...args));
       }
 
-      return get(value, 'validations');
+      return value.validations;
     }
 
     return true;
-  }
+  },
 });
 
 BelongsTo.reopenClass({
@@ -91,9 +90,9 @@ BelongsTo.reopenClass({
       `model.${attribute}.isDeleted`,
       `model.${attribute}.content.isDeleted`,
       `model.${attribute}.validations`,
-      `model.${attribute}.content.validations`
+      `model.${attribute}.content.validations`,
     ];
-  }
+  },
 });
 
 export default BelongsTo;

--- a/addon/validators/collection.js
+++ b/addon/validators/collection.js
@@ -1,4 +1,3 @@
-import { get } from '@ember/object';
 import EmberValidator from 'ember-cp-validations/-private/ember-validator';
 
 /**
@@ -46,19 +45,19 @@ const Collection = EmberValidator.extend({
 
     if (typeof options === 'boolean') {
       opts = {
-        collection: options
+        collection: options,
       };
     }
     return this._super(opts, defaultOptions, globalOptions);
-  }
+  },
 });
 
 Collection.reopenClass({
   getDependentsFor(attribute, options) {
-    return options === true || get(options, 'collection') === true
+    return options === true || options.collection === true
       ? [`model.${attribute}.[]`]
       : [];
-  }
+  },
 });
 
 export default Collection;

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -1,4 +1,3 @@
-import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import EmberValidator from 'ember-cp-validations/-private/ember-validator';
 
@@ -24,12 +23,12 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 const Confirmation = EmberValidator.extend({
-  _evType: 'confirmation'
+  _evType: 'confirmation',
 });
 
 Confirmation.reopenClass({
   getDependentsFor(attribute, options) {
-    let on = get(options, 'on');
+    let on = options.on;
 
     assert(
       `[validator:confirmation] [${attribute}] 'on' must be a string`,
@@ -37,7 +36,7 @@ Confirmation.reopenClass({
     );
 
     return on ? [`model.${on}`] : [];
-  }
+  },
 });
 
 export default Confirmation;

--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -25,5 +25,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _evType: 'date'
+  _evType: 'date',
 });

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -1,9 +1,8 @@
-import { getProperties, get } from '@ember/object';
+import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { isPresent, isEmpty, isNone } from '@ember/utils';
 import { isArray, A } from '@ember/array';
 import Base from 'ember-cp-validations/validators/base';
-import getWithDefault from '../utils/get-with-default';
 
 /**
  *  <i class="fa fa-hand-o-right" aria-hidden="true"></i> [See All Options](#method_validate)
@@ -33,7 +32,7 @@ const Dependent = Base.extend({
    * @param {String} attribute
    */
   validate(value, options, model, attribute) {
-    let { on, allowBlank } = getProperties(options, ['on', 'allowBlank']);
+    let { on, allowBlank } = options;
 
     assert(
       `[validator:dependent] [${attribute}] option 'on' is required`,
@@ -48,21 +47,21 @@ const Dependent = Base.extend({
       return true;
     }
 
-    let dependentValidations = getWithDefault(options, 'on', A()).map(
-      dependent => get(model, `validations.attrs.${dependent}`)
+    let dependentValidations = (on ?? A()).map((dependent) =>
+      get(model, `validations.attrs.${dependent}`)
     );
 
-    if (!isEmpty(dependentValidations.filter(v => get(v, 'isTruelyInvalid')))) {
+    if (!isEmpty(dependentValidations.filter((v) => v.isTruelyInvalid))) {
       return this.createErrorMessage('invalid', value, options);
     }
 
     return true;
-  }
+  },
 });
 
 Dependent.reopenClass({
   getDependentsFor(attribute, options) {
-    let dependents = get(options, 'on');
+    let dependents = options.on;
 
     assert(
       `[validator:dependent] [${attribute}] 'on' must be an array`,
@@ -70,11 +69,11 @@ Dependent.reopenClass({
     );
 
     if (!isEmpty(dependents)) {
-      return dependents.map(dependent => `${dependent}.isTruelyValid`);
+      return dependents.map((dependent) => `${dependent}.isTruelyValid`);
     }
 
     return [];
-  }
+  },
 });
 
 export default Dependent;

--- a/addon/validators/ds-error.js
+++ b/addon/validators/ds-error.js
@@ -18,7 +18,7 @@ import { getPathAndKey } from 'ember-validators/ds-error';
  *  @extends Base
  */
 const DSError = EmberValidator.extend({
-  _evType: 'ds-error'
+  _evType: 'ds-error',
 });
 
 DSError.reopenClass({
@@ -26,7 +26,7 @@ DSError.reopenClass({
     let { path, key } = getPathAndKey(attribute);
 
     return [`model.${path}.${key}.[]`];
-  }
+  },
 });
 
 export default DSError;

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -21,5 +21,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _evType: 'exclusion'
+  _evType: 'exclusion',
 });

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -43,5 +43,5 @@ import { regularExpressions } from 'ember-validators/format';
  */
 export default EmberValidator.extend({
   _evType: 'format',
-  regularExpressions
+  regularExpressions,
 });

--- a/addon/validators/has-many.js
+++ b/addon/validators/has-many.js
@@ -1,6 +1,5 @@
 import Base from 'ember-cp-validations/validators/base';
 import { isPromise } from 'ember-cp-validations/utils/utils';
-import { get } from '@ember/object';
 
 /**
  *  <i class="fa fa-hand-o-right" aria-hidden="true"></i> [See All Options](#method_validate)
@@ -53,14 +52,14 @@ const HasMany = Base.extend({
   validate(value, ...args) {
     if (value) {
       if (isPromise(value)) {
-        return value.then(models => this.validate(models, ...args));
+        return value.then((models) => this.validate(models, ...args));
       }
 
-      return value.map(m => get(m, 'validations'));
+      return value.map((m) => m.validations);
     }
 
     return true;
-  }
+  },
 });
 
 HasMany.reopenClass({
@@ -73,9 +72,9 @@ HasMany.reopenClass({
       `model.${attribute}.@each.isDeleted`,
       `model.${attribute}.content.@each.isDeleted`,
       `model.${attribute}.@each.validations`,
-      `model.${attribute}.content.@each.validations`
+      `model.${attribute}.content.@each.validations`,
     ];
-  }
+  },
 });
 
 export default HasMany;

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -36,5 +36,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _evType: 'inclusion'
+  _evType: 'inclusion',
 });

--- a/addon/validators/inline.js
+++ b/addon/validators/inline.js
@@ -45,5 +45,5 @@ export default Base.extend({
     delete opts.validate;
 
     return this._super(opts, ...args);
-  }
+  },
 });

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -22,5 +22,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _evType: 'length'
+  _evType: 'length',
 });

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -22,5 +22,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _evType: 'number'
+  _evType: 'number',
 });

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -50,9 +50,9 @@ export default EmberValidator.extend({
 
     if (typeof options === 'boolean') {
       opts = {
-        presence: options
+        presence: options,
       };
     }
     return this._super(opts, defaultOptions, globalOptions);
-  }
+  },
 });

--- a/blueprints/validator-test/index.js
+++ b/blueprints/validator-test/index.js
@@ -24,5 +24,5 @@ module.exports = {
   // workaround https://github.com/ember-cli/ember-cli/issues/5481
   supportsAddon() {
     return false;
-  }
+  },
 };

--- a/blueprints/validator/index.js
+++ b/blueprints/validator/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  description: 'Generates a validator and unit test'
+  description: 'Generates a validator and unit test',
 };

--- a/config/changelog.js
+++ b/config/changelog.js
@@ -17,5 +17,5 @@ module.exports = {
      groupSort: function(commits) { return { commits: commits }; },
      format: function(commit) { return commit.title; },
      */
-  }
+  },
 };

--- a/config/release.js
+++ b/config/release.js
@@ -9,12 +9,12 @@ module.exports = {
 
   beforeCommit: generateChangelog,
 
-  afterPublish: function(project, versions) {
+  afterPublish: function (project, versions) {
     runCommand(
       'ember github-pages:commit --message "Released ' + versions.next + '"'
     );
     runCommand('git push origin gh-pages:gh-pages');
-  }
+  },
 };
 
 function runCommand(command) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,8 +10,8 @@ module.exports = function (defaults) {
     'ember-bootstrap': {
       bootstrapVersion: 4,
       importBootstrapFont: true,
-      importBootstrapCSS: false
-    }
+      importBootstrapCSS: false,
+    },
   });
 
   /*

--- a/htmlbars-plugins/v-get.js
+++ b/htmlbars-plugins/v-get.js
@@ -156,18 +156,18 @@ function transform({ syntax }) {
     // (get model 'validations')
     let root = syntax.builders.sexpr(syntax.builders.path('get'), [
       params[0],
-      syntax.builders.string('validations')
+      syntax.builders.string('validations'),
     ]);
 
     // (get (get (get model 'validations') 'attrs') 'username')
     if (numParams === 3) {
       root = syntax.builders.sexpr(syntax.builders.path('get'), [
         root,
-        syntax.builders.string('attrs')
+        syntax.builders.string('attrs'),
       ]);
       root = syntax.builders.sexpr(syntax.builders.path('get'), [
         root,
-        params[1]
+        params[1],
       ]);
     }
 
@@ -187,8 +187,8 @@ function transform({ syntax }) {
       },
       ElementNode(node) {
         processNode(node);
-      }
-    }
+      },
+    },
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@
 module.exports = {
   name: require('./package').name,
 
-  setupPreprocessorRegistry: function(type, registry) {
+  setupPreprocessorRegistry: function (type, registry) {
     const plugin = this._buildPlugin();
 
     plugin.parallelBabel = {
       requireFile: __filename,
       buildUsing: '_buildPlugin',
-      params: {}
+      params: {},
     };
 
     registry.add('htmlbars-ast-plugin', plugin);
@@ -21,9 +21,9 @@ module.exports = {
     return {
       name: 'v-get',
       plugin: VGet,
-      baseDir: function() {
+      baseDir: function () {
         return __dirname;
-      }
+      },
     };
-  }
+  },
 };

--- a/tests/acceptance/dummy-index-test.js
+++ b/tests/acceptance/dummy-index-test.js
@@ -10,13 +10,13 @@ const validInputValues = {
   emailConfirmation: 'offirgolan@gmail.com',
   firstName: 'Offir',
   lastName: 'Golan',
-  dob: '1/1/1930'
+  dob: '1/1/1930',
 };
 
-module('Acceptance | Dummy | index', function(hooks) {
+module('Acceptance | Dummy | index', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('Page Loads', async function(assert) {
+  test('Page Loads', async function (assert) {
     assert.expect(2);
     await visit('/');
 
@@ -24,7 +24,7 @@ module('Acceptance | Dummy | index', function(hooks) {
     assert.dom('.form .register h2').hasText('Create an Account');
   });
 
-  test('Helper tooltips', async function(assert) {
+  test('Helper tooltips', async function (assert) {
     assert.expect(2);
     await visit('/');
 
@@ -34,7 +34,7 @@ module('Acceptance | Dummy | index', function(hooks) {
       .includesText('These form inputs are bound to the User model');
   });
 
-  test('Invalid form submit', async function(assert) {
+  test('Invalid form submit', async function (assert) {
     await visit('/');
     await click('[data-test-sign-up]');
 
@@ -43,7 +43,7 @@ module('Acceptance | Dummy | index', function(hooks) {
       .hasText('Please fix all the errors below before continuing.');
   });
 
-  test('Valid form submit', async function(assert) {
+  test('Valid form submit', async function (assert) {
     await visit('/');
 
     for (let key in validInputValues) {
@@ -61,7 +61,7 @@ module('Acceptance | Dummy | index', function(hooks) {
     assert.dom('.form .registered h2.success').hasText('Success');
   });
 
-  test('Invalid to valid email', async function(assert) {
+  test('Invalid to valid email', async function (assert) {
     assert.expect(4);
     await visit('/');
 

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,3 +1,3 @@
-import RESTAPIAdapter from 'ember-data/adapters/rest';
+import RESTAPIAdapter from '@ember-data/adapter/rest';
 
 export default RESTAPIAdapter.extend({});

--- a/tests/dummy/app/components/validated-input.js
+++ b/tests/dummy/app/components/validated-input.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-classic-components */
 // BEGIN-SNIPPET validated-input
 import {
   not,
@@ -5,12 +6,13 @@ import {
   and,
   or,
   readOnly,
-  alias
+  alias,
 } from '@ember/object/computed';
 
 import Component from '@ember/component';
 import { defineProperty } from '@ember/object';
 
+// eslint-disable-next-line ember/require-tagless-components
 export default Component.extend({
   classNames: ['validated-input'],
   classNameBindings: ['showErrorClass:has-error', 'isValid:has-success'],
@@ -51,7 +53,7 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let valuePath = this.get('valuePath');
+    let valuePath = this.valuePath;
 
     defineProperty(
       this,
@@ -64,6 +66,6 @@ export default Component.extend({
   focusOut() {
     this._super(...arguments);
     this.set('showValidations', true);
-  }
+  },
 });
 // END-SNIPPET

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -6,27 +6,26 @@ export default Controller.extend({
   showCode: false,
   didValidate: false,
 
+  // eslint-disable-next-line ember/no-actions-hash
   actions: {
     validate() {
-      this.get('model')
-        .validate()
-        .then(({ validations }) => {
-          this.set('didValidate', true);
+      this.model.validate().then(({ validations }) => {
+        this.set('didValidate', true);
 
-          if (validations.get('isValid')) {
-            this.setProperties({
-              showAlert: false,
-              isRegistered: true,
-              showCode: false
-            });
-          } else {
-            this.set('showAlert', true);
-          }
-        });
+        if (validations.get('isValid')) {
+          this.setProperties({
+            showAlert: false,
+            isRegistered: true,
+            showCode: false,
+          });
+        } else {
+          this.set('showAlert', true);
+        }
+      });
     },
 
     toggleProperty(p) {
       this.toggleProperty(p);
-    }
-  }
+    },
+  },
 });

--- a/tests/dummy/app/models/company.js
+++ b/tests/dummy/app/models/company.js
@@ -1,10 +1,10 @@
-import DS from 'ember-data';
+import Model, { attr } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 export const Validations = buildValidations({
-  name: validator('presence', { presence: true, description: 'Name' })
+  name: validator('presence', { presence: true, description: 'Name' }),
 });
 
-export default DS.Model.extend(Validations, {
-  name: DS.attr('string')
+export default Model.extend(Validations, {
+  name: attr('string'),
 });

--- a/tests/dummy/app/models/order-line.js
+++ b/tests/dummy/app/models/order-line.js
@@ -1,27 +1,27 @@
-import DS from 'ember-data';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations({
   type: {
     description: 'Order Line Type',
-    validators: [validator('ds-error'), validator('presence', true)]
+    validators: [validator('ds-error'), validator('presence', true)],
   },
   order: {
     description: 'Order',
-    validators: [validator('ds-error'), validator('presence', true)]
+    validators: [validator('ds-error'), validator('presence', true)],
   },
   selections: {
     description: 'Order Selections',
     validators: [
       validator('ds-error'),
       validator('has-many'),
-      validator('presence', true)
-    ]
-  }
+      validator('presence', true),
+    ],
+  },
 });
 
-export default DS.Model.extend(Validations, {
-  order: DS.belongsTo('order', { async: true }),
-  selections: DS.hasMany('order-selection', { async: true }),
-  type: DS.attr('string')
+export default Model.extend(Validations, {
+  order: belongsTo('order', { async: true }),
+  selections: hasMany('order-selection', { async: true }),
+  type: attr('string'),
 });

--- a/tests/dummy/app/models/order-selection-question.js
+++ b/tests/dummy/app/models/order-selection-question.js
@@ -1,28 +1,28 @@
-import DS from 'ember-data';
+import Model, { attr, belongsTo } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations(
   {
     order: {
       description: 'Order',
-      validators: [validator('ds-error'), validator('presence', true)]
+      validators: [validator('ds-error'), validator('presence', true)],
     },
     selection: {
       description: 'Order Selection',
-      validators: [validator('ds-error'), validator('presence', true)]
+      validators: [validator('ds-error'), validator('presence', true)],
     },
     text: {
       description: 'Question Text',
-      validators: [validator('ds-error'), validator('presence', true)]
-    }
+      validators: [validator('ds-error'), validator('presence', true)],
+    },
   },
   {
-    debounce: 10
+    debounce: 10,
   }
 );
 
-export default DS.Model.extend(Validations, {
-  order: DS.belongsTo('order', { async: true }),
-  selection: DS.belongsTo('order-selection', { async: true }),
-  text: DS.attr('string')
+export default Model.extend(Validations, {
+  order: belongsTo('order', { async: true }),
+  selection: belongsTo('order-selection', { async: true }),
+  text: attr('string'),
 });

--- a/tests/dummy/app/models/order-selection.js
+++ b/tests/dummy/app/models/order-selection.js
@@ -1,4 +1,4 @@
-import DS from 'ember-data';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations({
@@ -7,21 +7,21 @@ const Validations = buildValidations({
     validators: [
       validator('ds-error'),
       validator('number', {
-        gte: 1
-      })
-    ]
+        gte: 1,
+      }),
+    ],
   },
   order: {
     description: 'Order',
     validators: [
       validator('ds-error'),
       validator('belongs-to'),
-      validator('presence', true)
-    ]
+      validator('presence', true),
+    ],
   },
   line: {
     description: 'Order Line',
-    validators: [validator('ds-error'), validator('presence', true)]
+    validators: [validator('ds-error'), validator('presence', true)],
   },
   questions: {
     description: 'Order Selection Questions',
@@ -29,15 +29,15 @@ const Validations = buildValidations({
       validator('ds-error'),
       validator('has-many'),
       validator('length', {
-        min: 1
-      })
-    ]
-  }
+        min: 1,
+      }),
+    ],
+  },
 });
 
-export default DS.Model.extend(Validations, {
-  order: DS.belongsTo('order', { async: true }),
-  line: DS.belongsTo('order-line', { async: true }),
-  questions: DS.hasMany('order-selection-question', { async: true }),
-  quantity: DS.attr('number')
+export default Model.extend(Validations, {
+  order: belongsTo('order', { async: true }),
+  line: belongsTo('order-line', { async: true }),
+  questions: hasMany('order-selection-question', { async: true }),
+  quantity: attr('number'),
 });

--- a/tests/dummy/app/models/order.js
+++ b/tests/dummy/app/models/order.js
@@ -1,22 +1,22 @@
-import DS from 'ember-data';
+import Model, { attr, hasMany } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const Validations = buildValidations({
   source: {
     description: 'Order Source',
-    validators: [validator('ds-error'), validator('presence', true)]
+    validators: [validator('ds-error'), validator('presence', true)],
   },
   lines: {
     description: 'Order Lines',
     validators: [
       validator('ds-error'),
       validator('has-many'),
-      validator('presence', true)
-    ]
-  }
+      validator('presence', true),
+    ],
+  },
 });
 
-export default DS.Model.extend(Validations, {
-  source: DS.attr('string'),
-  lines: DS.hasMany('order-line', { async: true })
+export default Model.extend(Validations, {
+  source: attr('string'),
+  lines: hasMany('order-line', { async: true }),
 });

--- a/tests/dummy/app/models/signup.js
+++ b/tests/dummy/app/models/signup.js
@@ -1,4 +1,4 @@
-import DS from 'ember-data';
+import Model, { attr } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 let Validations = buildValidations({
@@ -6,11 +6,11 @@ let Validations = buildValidations({
   acceptTerms: validator('inline', {
     validate(value) {
       return value || 'You must accept the terms.';
-    }
-  })
+    },
+  }),
 });
 
-export default DS.Model.extend(Validations, {
-  name: DS.attr('string', { defaultValue: '' }),
-  acceptTerms: DS.attr('boolean', { defaultValue: false })
+export default Model.extend(Validations, {
+  name: attr('string', { defaultValue: '' }),
+  acceptTerms: attr('boolean', { defaultValue: false }),
 });

--- a/tests/dummy/app/models/user-detail.js
+++ b/tests/dummy/app/models/user-detail.js
@@ -1,11 +1,9 @@
 // BEGIN-SNIPPET user-detail-model
 import { computed } from '@ember/object';
 
-import DS from 'ember-data';
+import Model, { attr } from '@ember-data/model';
 import moment from 'moment';
 import { validator, buildValidations } from 'ember-cp-validations';
-
-const { attr } = DS;
 
 const Validations = buildValidations(
   {
@@ -16,10 +14,8 @@ const Validations = buildValidations(
       validators: [
         validator('presence', true),
         validator('date', {
-          after: computed(function() {
-            return moment()
-              .subtract(120, 'years')
-              .format('M/D/YYYY');
+          after: computed(function () {
+            return moment().subtract(120, 'years').format('M/D/YYYY');
           }).volatile(),
           format: 'M/D/YYYY',
           message(type, value /*, context */) {
@@ -32,33 +28,33 @@ const Validations = buildValidations(
                 'years'
               )} years old`;
             }
-          }
-        })
-      ]
+          },
+        }),
+      ],
     },
     phone: [
       validator('format', {
         allowBlank: true,
-        type: 'phone'
-      })
+        type: 'phone',
+      }),
     ],
     url: [
       validator('format', {
         allowBlank: true,
-        type: 'url'
-      })
-    ]
+        type: 'url',
+      }),
+    ],
   },
   {
-    debounce: 500
+    debounce: 500,
   }
 );
 
-export default DS.Model.extend(Validations, {
+export default Model.extend(Validations, {
   firstName: attr('string'),
   lastName: attr('string'),
   dob: attr('date'),
   phone: attr('string'),
-  url: attr('string')
+  url: attr('string'),
 });
 // END-SNIPPET

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,8 +1,6 @@
 // BEGIN-SNIPPET user-model
-import DS from 'ember-data';
+import Model, { attr, belongsTo } from '@ember-data/model';
 import { validator, buildValidations } from 'ember-cp-validations';
-
-const { attr } = DS;
 
 const Validations = buildValidations(
   {
@@ -12,9 +10,9 @@ const Validations = buildValidations(
         validator('presence', true),
         validator('length', {
           min: 5,
-          max: 15
-        })
-      ]
+          max: 15,
+        }),
+      ],
     },
     password: {
       description: 'Password',
@@ -22,43 +20,43 @@ const Validations = buildValidations(
         validator('presence', true),
         validator('length', {
           min: 4,
-          max: 10
+          max: 10,
         }),
         validator('format', {
           regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,10}$/,
           message:
-            '{description} must include at least one upper case letter, one lower case letter, and a number'
+            '{description} must include at least one upper case letter, one lower case letter, and a number',
         }),
         validator('length', {
           isWarning: true,
           min: 6,
-          message: 'What kind of weak password is that?'
-        })
-      ]
+          message: 'What kind of weak password is that?',
+        }),
+      ],
     },
     email: {
       validators: [
         validator('presence', true),
         validator('format', {
-          type: 'email'
-        })
-      ]
+          type: 'email',
+        }),
+      ],
     },
     emailConfirmation: validator('confirmation', {
       on: 'email',
-      message: 'Email addresses do not match'
+      message: 'Email addresses do not match',
     }),
-    details: validator('belongs-to')
+    details: validator('belongs-to'),
   },
   {
-    debounce: 500
+    debounce: 500,
   }
 );
 
-export default DS.Model.extend(Validations, {
+export default Model.extend(Validations, {
   username: attr('string'),
   password: attr('string'),
   email: attr('string'),
-  details: DS.belongsTo('user-detail')
+  details: belongsTo('user-detail'),
 });
 // END-SNIPPET

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,4 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function() {});
+Router.map(function () {});

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-actions-hash */
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -6,7 +7,7 @@ export default Route.extend({
 
   model() {
     return this.store.createRecord('user', {
-      details: this.store.createRecord('user-detail')
+      details: this.store.createRecord('user-detail'),
     });
   },
 
@@ -15,7 +16,7 @@ export default Route.extend({
       showAlert: false,
       isRegistered: false,
       showCode: false,
-      didValidate: false
+      didValidate: false,
     });
 
     this._super(...arguments);
@@ -24,6 +25,6 @@ export default Route.extend({
   actions: {
     reset() {
       this.refresh();
-    }
-  }
+    },
+  },
 });

--- a/tests/dummy/app/validators/messages.js
+++ b/tests/dummy/app/validators/messages.js
@@ -1,5 +1,5 @@
 import Messages from 'ember-cp-validations/validators/messages';
 
 export default Messages.extend({
-  test: 'Test error message'
+  test: 'Test error message',
 });

--- a/tests/helpers/setup-object.js
+++ b/tests/helpers/setup-object.js
@@ -1,3 +1,3 @@
-export default function(context, obj, options = {}) {
+export default function (context, obj, options = {}) {
   return obj.create(context.owner.ownerInjection(), options);
 }

--- a/tests/integration/helpers/v-get-test.js
+++ b/tests/integration/helpers/v-get-test.js
@@ -4,10 +4,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | v-get', function(hooks) {
+module('Integration | Helper | v-get', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     let model = EmberObject.create({
       validations: {
         isValid: false,
@@ -15,26 +15,26 @@ module('Integration | Helper | v-get', function(hooks) {
         attrs: {
           username: {
             isValid: false,
-            message: 'This field is invalid'
+            message: 'This field is invalid',
           },
           email: {
-            isValid: true
-          }
-        }
-      }
+            isValid: true,
+          },
+        },
+      },
     });
 
     this.set('model', model);
   });
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     assert.expect(1);
 
     await render(hbs`{{v-get model 'isValid'}}`);
     assert.dom(this.element).hasText('false');
   });
 
-  test('access attribute validations', async function(assert) {
+  test('access attribute validations', async function (assert) {
     assert.expect(3);
 
     await render(hbs`{{v-get model 'username' 'isValid'}}`);
@@ -47,7 +47,7 @@ module('Integration | Helper | v-get', function(hooks) {
     assert.dom(this.element).hasText('true');
   });
 
-  test('updating validation should rerender', async function(assert) {
+  test('updating validation should rerender', async function (assert) {
     assert.expect(2);
 
     await render(hbs`{{v-get model 'username' 'isValid'}}`);
@@ -58,7 +58,7 @@ module('Integration | Helper | v-get', function(hooks) {
     assert.dom(this.element).hasText('true');
   });
 
-  test('block statement param', async function(assert) {
+  test('block statement param', async function (assert) {
     assert.expect(2);
 
     await render(hbs`
@@ -78,7 +78,7 @@ module('Integration | Helper | v-get', function(hooks) {
     assert.dom(this.element).hasText('This field is invalid');
   });
 
-  test('element node attribute', async function(assert) {
+  test('element node attribute', async function (assert) {
     assert.expect(2);
 
     await render(
@@ -89,7 +89,7 @@ module('Integration | Helper | v-get', function(hooks) {
     assert.equal(this.element.querySelector('button').disabled, true);
   });
 
-  test('element node attribute in class string', async function(assert) {
+  test('element node attribute in class string', async function (assert) {
     assert.expect(3);
 
     await render(
@@ -105,7 +105,7 @@ module('Integration | Helper | v-get', function(hooks) {
       .hasClass('has-error', 'error class present');
   });
 
-  test('access validations with named args', async function(assert) {
+  test('access validations with named args', async function (assert) {
     assert.expect(2);
 
     await render(hbs`{{named-v-get model=model field='isValid'}}`);

--- a/tests/integration/validations/factory-dependent-keys-test.js
+++ b/tests/integration/validations/factory-dependent-keys-test.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import EmberObject from '@ember/object';
-import DS from 'ember-data';
+import { Errors } from '@ember-data/model/-private';
 import setupObject from '../../helpers/setup-object';
 import CollectionValidator from 'dummy/validators/collection';
 import LengthValidator from 'dummy/validators/length';
@@ -9,157 +9,122 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import { module, test, skip } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Integration | Validations | Factory - Dependent Keys', function(hooks) {
-  setupTest(hooks);
+module(
+  'Integration | Validations | Factory - Dependent Keys',
+  function (hooks) {
+    setupTest(hooks);
 
-  test('collection validator creates correct dependent keys', function(assert) {
-    this.owner.register('validator:collection', CollectionValidator);
-    this.owner.register('validator:length', LengthValidator);
+    test('collection validator creates correct dependent keys', function (assert) {
+      this.owner.register('validator:collection', CollectionValidator);
+      this.owner.register('validator:length', LengthValidator);
 
-    let CollectionValidations = buildValidations({
-      array: [
-        validator('collection', true),
-        validator('length', {
-          is: 2,
-          message: 'Array must have {is} items'
-        })
-      ]
-    });
-    let obj = setupObject(this, EmberObject.extend(CollectionValidations), {
-      array: A(['foo', 'bar'])
-    });
+      let CollectionValidations = buildValidations({
+        array: [
+          validator('collection', true),
+          validator('length', {
+            is: 2,
+            message: 'Array must have {is} items',
+          }),
+        ],
+      });
+      let obj = setupObject(this, EmberObject.extend(CollectionValidations), {
+        array: A(['foo', 'bar']),
+      });
 
-    assert.equal(obj.get('validations.attrs.array.isValid'), true);
+      assert.equal(obj.get('validations.attrs.array.isValid'), true);
 
-    obj.get('array').removeObject('bar');
+      obj.get('array').removeObject('bar');
 
-    assert.equal(obj.get('validations.attrs.array.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.array.message'),
-      'Array must have 2 items'
-    );
-  });
-
-  test('ds-error validator creates correct dependent keys', function(assert) {
-    this.owner.register('validator:ds-error', DSErrorValidator);
-    this.owner.register('validator:length', LengthValidator);
-
-    let DSErrorValidations = buildValidations({
-      username: validator('ds-error')
-    });
-    let obj = setupObject(this, EmberObject.extend(DSErrorValidations), {
-      errors: DS.Errors.create(),
-      username: ''
+      assert.equal(obj.get('validations.attrs.array.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.array.message'),
+        'Array must have 2 items'
+      );
     });
 
-    assert.equal(obj.get('validations.attrs.username.isValid'), true);
+    test('ds-error validator creates correct dependent keys', function (assert) {
+      this.owner.register('validator:ds-error', DSErrorValidator);
+      this.owner.register('validator:length', LengthValidator);
 
-    obj.get('errors').add('username', 'Username is not unique');
+      let DSErrorValidations = buildValidations({
+        username: validator('ds-error'),
+      });
+      let obj = setupObject(this, EmberObject.extend(DSErrorValidations), {
+        errors: Errors.create(),
+        username: '',
+      });
 
-    assert.equal(obj.get('validations.attrs.username.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.username.message'),
-      'Username is not unique'
-    );
-  });
+      assert.equal(obj.get('validations.attrs.username.isValid'), true);
 
-  // ember-validators v4.0.0 broke the ds-error validator for nested objects
-  skip('nested ds-error validator creates correct dependent keys', function(assert) {
-    this.owner.register('validator:ds-error', DSErrorValidator);
-    this.owner.register('validator:length', LengthValidator);
+      obj.get('errors').add('username', 'Username is not unique');
 
-    let DSErrorValidations = buildValidations({
-      'model.username': validator('ds-error')
+      assert.equal(obj.get('validations.attrs.username.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.username.message'),
+        'Username is not unique'
+      );
     });
 
-    let obj = setupObject(this, EmberObject.extend(DSErrorValidations), {
-      model: EmberObject.create({
-        errors: DS.Errors.create(),
-        username: ''
-      })
+    // ember-validators v4.0.0 broke the ds-error validator for nested objects
+    skip('nested ds-error validator creates correct dependent keys', function (assert) {
+      this.owner.register('validator:ds-error', DSErrorValidator);
+      this.owner.register('validator:length', LengthValidator);
+
+      let DSErrorValidations = buildValidations({
+        'model.username': validator('ds-error'),
+      });
+
+      let obj = setupObject(this, EmberObject.extend(DSErrorValidations), {
+        model: EmberObject.create({
+          errors: Errors.create(),
+          username: '',
+        }),
+      });
+
+      assert.equal(obj.get('validations.attrs.model.username.isValid'), true);
+
+      obj.get('model.errors').add('username', 'Username is not unique');
+
+      assert.equal(obj.get('validations.attrs.model.username.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.model.username.message'),
+        'Username is not unique'
+      );
     });
 
-    assert.equal(obj.get('validations.attrs.model.username.isValid'), true);
-
-    obj.get('model.errors').add('username', 'Username is not unique');
-
-    assert.equal(obj.get('validations.attrs.model.username.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.model.username.message'),
-      'Username is not unique'
-    );
-  });
-
-  test('custom dependent keys - simple', function(assert) {
-    let Validations = buildValidations({
-      fullName: validator('inline', {
-        dependentKeys: ['model.firstName', 'model.lastName'],
-        validate(value, options, model) {
-          let firstName = model.get('firstName');
-          let lastName = model.get('lastName');
-          if (!firstName || !lastName) {
-            return 'Full name requires first and last name';
-          }
-          return true;
-        }
-      })
-    });
-
-    let obj = setupObject(this, EmberObject.extend(Validations));
-
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.fullName.message'),
-      'Full name requires first and last name'
-    );
-
-    obj.set('firstName', 'Offir');
-    obj.set('lastName', 'Golan');
-
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
-  });
-
-  test('custom dependent keys - default options', function(assert) {
-    let Validations = buildValidations({
-      fullName: {
-        dependentKeys: ['model.firstName'],
-        validators: [
-          validator('inline', {
-            dependentKeys: ['model.lastName'],
-            validate(value, options, model) {
-              let firstName = model.get('firstName');
-              let lastName = model.get('lastName');
-              if (!firstName || !lastName) {
-                return 'Full name requires first and last name';
-              }
-              return true;
+    test('custom dependent keys - simple', function (assert) {
+      let Validations = buildValidations({
+        fullName: validator('inline', {
+          dependentKeys: ['model.firstName', 'model.lastName'],
+          validate(value, options, model) {
+            let firstName = model.get('firstName');
+            let lastName = model.get('lastName');
+            if (!firstName || !lastName) {
+              return 'Full name requires first and last name';
             }
-          })
-        ]
-      }
+            return true;
+          },
+        }),
+      });
+
+      let obj = setupObject(this, EmberObject.extend(Validations));
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.fullName.message'),
+        'Full name requires first and last name'
+      );
+
+      obj.set('firstName', 'Offir');
+      obj.set('lastName', 'Golan');
+
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
     });
 
-    let obj = setupObject(this, EmberObject.extend(Validations));
-
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.fullName.message'),
-      'Full name requires first and last name'
-    );
-
-    obj.set('firstName', 'Offir');
-    obj.set('lastName', 'Golan');
-
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
-  });
-
-  test('custom dependent keys - global options', function(assert) {
-    let Validations = buildValidations(
-      {
+    test('custom dependent keys - default options', function (assert) {
+      let Validations = buildValidations({
         fullName: {
           dependentKeys: ['model.firstName'],
           validators: [
@@ -168,170 +133,208 @@ module('Integration | Validations | Factory - Dependent Keys', function(hooks) {
               validate(value, options, model) {
                 let firstName = model.get('firstName');
                 let lastName = model.get('lastName');
-                let middleName = model.get('middleName');
-                if (!firstName || !lastName || !middleName) {
-                  return 'Full name requires first, middle, and last name';
+                if (!firstName || !lastName) {
+                  return 'Full name requires first and last name';
                 }
                 return true;
-              }
-            })
-          ]
-        }
-      },
-      {
-        dependentKeys: ['model.middleName']
-      }
-    );
+              },
+            }),
+          ],
+        },
+      });
 
-    let obj = setupObject(this, EmberObject.extend(Validations));
+      let obj = setupObject(this, EmberObject.extend(Validations));
 
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.fullName.message'),
-      'Full name requires first, middle, and last name'
-    );
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.fullName.message'),
+        'Full name requires first and last name'
+      );
 
-    obj.set('firstName', 'Offir');
-    obj.set('lastName', 'Golan');
+      obj.set('firstName', 'Offir');
+      obj.set('lastName', 'Golan');
 
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
-
-    obj.set('middleName', 'David');
-
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
-  });
-
-  test('custom dependent keys - nested object', function(assert) {
-    let Validations = buildValidations({
-      page: validator('inline', {
-        dependentKeys: ['model.currPage', 'model.meta.pages.last'],
-        validate(value, options, model) {
-          let currPage = model.get('currPage');
-          let lastPage = model.get('meta.pages.last');
-          if (currPage > lastPage) {
-            return 'Cannot exceed max page';
-          }
-          return true;
-        }
-      })
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
     });
 
-    let obj = setupObject(this, EmberObject.extend(Validations), {
-      meta: {
-        pages: {
-          last: 5
+    test('custom dependent keys - global options', function (assert) {
+      let Validations = buildValidations(
+        {
+          fullName: {
+            dependentKeys: ['model.firstName'],
+            validators: [
+              validator('inline', {
+                dependentKeys: ['model.lastName'],
+                validate(value, options, model) {
+                  let firstName = model.get('firstName');
+                  let lastName = model.get('lastName');
+                  let middleName = model.get('middleName');
+                  if (!firstName || !lastName || !middleName) {
+                    return 'Full name requires first, middle, and last name';
+                  }
+                  return true;
+                },
+              }),
+            ],
+          },
+        },
+        {
+          dependentKeys: ['model.middleName'],
         }
-      },
-      currPage: 4
+      );
+
+      let obj = setupObject(this, EmberObject.extend(Validations));
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.fullName.message'),
+        'Full name requires first, middle, and last name'
+      );
+
+      obj.set('firstName', 'Offir');
+      obj.set('lastName', 'Golan');
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+
+      obj.set('middleName', 'David');
+
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
     });
 
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.page.isValid'), true);
-
-    obj.set('currPage', 6);
-
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.page.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.page.message'),
-      'Cannot exceed max page'
-    );
-
-    obj.set('meta.pages.last', 7);
-
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.page.isValid'), true);
-  });
-
-  test('custom dependent keys - array', function(assert) {
-    let Validations = buildValidations({
-      friends: validator('inline', {
-        dependentKeys: ['model.friends.[]'],
-        validate(value, options, model) {
-          let friends = model.get('friends');
-          if (!friends || friends.length === 0) {
-            return 'User must have a friend';
-          }
-          return true;
-        }
-      })
-    });
-
-    let obj = setupObject(this, EmberObject.extend(Validations), {
-      friends: A()
-    });
-
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.friends.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.friends.message'),
-      'User must have a friend'
-    );
-
-    obj.get('friends').pushObject('Offir');
-
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.friends.isValid'), true);
-
-    obj.get('friends').removeObject('Offir');
-
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.friends.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.friends.message'),
-      'User must have a friend'
-    );
-  });
-
-  test('custom dependent keys - array of objects', function(assert) {
-    let Validations = buildValidations({
-      friends: validator('inline', {
-        dependentKeys: ['model.friends.@each.name'],
-        validate(value, options, model) {
-          let friends = model.get('friends');
-          if (!friends || friends.length === 0) {
-            return 'User must have a friend';
-          } else if (friends.length > 0) {
-            let names = friends.filter(f => f.name);
-            if (names.length !== friends.length) {
-              return 'All friends must have a name';
+    test('custom dependent keys - nested object', function (assert) {
+      let Validations = buildValidations({
+        page: validator('inline', {
+          dependentKeys: ['model.currPage', 'model.meta.pages.last'],
+          validate(value, options, model) {
+            let currPage = model.get('currPage');
+            let lastPage = model.get('meta.pages.last');
+            if (currPage > lastPage) {
+              return 'Cannot exceed max page';
             }
-          }
-          return true;
-        }
-      })
+            return true;
+          },
+        }),
+      });
+
+      let obj = setupObject(this, EmberObject.extend(Validations), {
+        meta: {
+          pages: {
+            last: 5,
+          },
+        },
+        currPage: 4,
+      });
+
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.page.isValid'), true);
+
+      obj.set('currPage', 6);
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.page.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.page.message'),
+        'Cannot exceed max page'
+      );
+
+      obj.set('meta.pages.last', 7);
+
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.page.isValid'), true);
     });
 
-    let obj = setupObject(this, EmberObject.extend(Validations), {
-      friends: A()
+    test('custom dependent keys - array', function (assert) {
+      let Validations = buildValidations({
+        friends: validator('inline', {
+          dependentKeys: ['model.friends.[]'],
+          validate(value, options, model) {
+            let friends = model.get('friends');
+            if (!friends || friends.length === 0) {
+              return 'User must have a friend';
+            }
+            return true;
+          },
+        }),
+      });
+
+      let obj = setupObject(this, EmberObject.extend(Validations), {
+        friends: A(),
+      });
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.friends.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.friends.message'),
+        'User must have a friend'
+      );
+
+      obj.get('friends').pushObject('Offir');
+
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.friends.isValid'), true);
+
+      obj.get('friends').removeObject('Offir');
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.friends.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.friends.message'),
+        'User must have a friend'
+      );
     });
 
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.friends.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.friends.message'),
-      'User must have a friend'
-    );
+    test('custom dependent keys - array of objects', function (assert) {
+      let Validations = buildValidations({
+        friends: validator('inline', {
+          dependentKeys: ['model.friends.@each.name'],
+          validate(value, options, model) {
+            let friends = model.get('friends');
+            if (!friends || friends.length === 0) {
+              return 'User must have a friend';
+            } else if (friends.length > 0) {
+              let names = friends.filter((f) => f.name);
+              if (names.length !== friends.length) {
+                return 'All friends must have a name';
+              }
+            }
+            return true;
+          },
+        }),
+      });
 
-    obj.get('friends').pushObject(
-      EmberObject.create({
-        name: 'Offir'
-      })
-    );
+      let obj = setupObject(this, EmberObject.extend(Validations), {
+        friends: A(),
+      });
 
-    assert.equal(obj.get('validations.isValid'), true);
-    assert.equal(obj.get('validations.attrs.friends.isValid'), true);
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.friends.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.friends.message'),
+        'User must have a friend'
+      );
 
-    obj.get('friends.0').set('name', undefined);
+      obj.get('friends').pushObject(
+        EmberObject.create({
+          name: 'Offir',
+        })
+      );
 
-    assert.equal(obj.get('validations.isValid'), false);
-    assert.equal(obj.get('validations.attrs.friends.isValid'), false);
-    assert.equal(
-      obj.get('validations.attrs.friends.message'),
-      'All friends must have a name'
-    );
-  });
-});
+      assert.equal(obj.get('validations.isValid'), true);
+      assert.equal(obj.get('validations.attrs.friends.isValid'), true);
+
+      obj.get('friends.0').set('name', undefined);
+
+      assert.equal(obj.get('validations.isValid'), false);
+      assert.equal(obj.get('validations.attrs.friends.isValid'), false);
+      assert.equal(
+        obj.get('validations.attrs.friends.message'),
+        'All friends must have a name'
+      );
+    });
+  }
+);

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -21,22 +21,22 @@ const Validators = {
       return `${attr} should be present`;
     }
     return true;
-  }
+  },
 };
 
 let Validations = buildValidations({
   firstName: validator('inline', { validate: Validators.presence }),
-  lastName: validator('inline', { validate: Validators.presence })
+  lastName: validator('inline', { validate: Validators.presence }),
 });
 
-module('Integration | Validations | Factory - General', function(hooks) {
+module('Integration | Validations | Factory - General', function (hooks) {
   setupTest(hooks);
 
-  test('it works', function(assert) {
+  test('it works', function (assert) {
     assert.ok(buildValidations());
   });
 
-  test('basic sync validation – invalid', function(assert) {
+  test('basic sync validation – invalid', function (assert) {
     let object = setupObject(this, EmberObject.extend(Validations));
 
     assert.equal(
@@ -141,10 +141,10 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('basic sync validation - valid', function(assert) {
+  test('basic sync validation - valid', function (assert) {
     let object = setupObject(this, EmberObject.extend(Validations), {
       firstName: 'Stef',
-      lastName: 'Penner'
+      lastName: 'Penner',
     });
 
     assert.equal(
@@ -177,9 +177,9 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.attrs.lastName.message'), null);
   });
 
-  test('basic sync validation - 50% invalid', function(assert) {
+  test('basic sync validation - 50% invalid', function (assert) {
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Stef'
+      firstName: 'Stef',
     });
 
     assert.equal(
@@ -215,9 +215,9 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('basic sync validation - API - #validation', function(assert) {
+  test('basic sync validation - API - #validation', function (assert) {
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Stef'
+      firstName: 'Stef',
     });
 
     return object
@@ -226,10 +226,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
       .then(({ validations, model }) => {
         assert.equal(model, object, 'expected model to be the correct model');
         assert.deepEqual(
-          validations
-            .get('content')
-            .getEach('attribute')
-            .sort(),
+          validations.get('content').getEach('attribute').sort(),
           ['firstName', 'lastName'].sort()
         );
 
@@ -288,19 +285,16 @@ module('Integration | Validations | Factory - General', function(hooks) {
       });
   });
 
-  test('basic sync validation - API - #validationSync', function(assert) {
+  test('basic sync validation - API - #validationSync', function (assert) {
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Stef'
+      firstName: 'Stef',
     });
 
     let { validations, model } = object.get('validations').validateSync();
 
     assert.equal(model, object, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['firstName', 'lastName'].sort()
     );
 
@@ -348,12 +342,12 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('basic sync validation returns null', function(assert) {
+  test('basic sync validation returns null', function (assert) {
     let Validations = buildValidations({
-      firstName: validator('inline', { validate: () => null })
+      firstName: validator('inline', { validate: () => null }),
     });
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     assert.equal(
@@ -382,15 +376,15 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.attrs.firstName.message'), undefined);
   });
 
-  test('shallow isAsync test', function(assert) {
+  test('shallow isAsync test', function (assert) {
     let Validations = buildValidations({
       firstName: validator('inline', {
         validate() {
-          return new EmberPromise(resolve => {
+          return new EmberPromise((resolve) => {
             resolve(true);
           });
-        }
-      })
+        },
+      }),
     });
 
     let obj = setupObject(this, EmberObject.extend(Validations));
@@ -404,43 +398,43 @@ module('Integration | Validations | Factory - General', function(hooks) {
     });
   });
 
-  test('default options', function(assert) {
+  test('default options', function (assert) {
     let Validations = buildValidations({
       firstName: {
         description: 'Test field',
         validators: [
           validator('inline', { validate: Validators.presence }),
-          validator('inline', { validate: () => false })
-        ]
-      }
+          validator('inline', { validate: () => false }),
+        ],
+      },
     });
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: ''
+      firstName: '',
     });
     let rules = A(object.get('validations._validationRules.firstName'));
     assert.equal(rules.isAny('defaultOptions', undefined), false);
     assert.equal(rules[0].defaultOptions.description, 'Test field');
   });
 
-  test('global options', function(assert) {
+  test('global options', function (assert) {
     this.owner.register('validator:length', LengthValidator);
 
     let Validations = buildValidations(
       {
         firstName: {
           description: 'Test field',
-          validators: [validator('length', { min: 1, max: 5 })]
-        }
+          validators: [validator('length', { min: 1, max: 5 })],
+        },
       },
       {
         message: 'Global error message',
         description: 'Default field',
-        max: 10
+        max: 10,
       }
     );
 
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: ''
+      firstName: '',
     });
 
     // Global options present in rules
@@ -457,19 +451,19 @@ module('Integration | Validations | Factory - General', function(hooks) {
         message: 'Global error message',
         description: 'Test field',
         min: 1,
-        max: 5
+        max: 5,
       }
     );
   });
 
-  test('custom messages object', function(assert) {
+  test('custom messages object', function (assert) {
     this.owner.register('validator:messages', DefaultMessages);
     let Validations = buildValidations({
       firstName: validator('inline', {
         validate(value) {
           return this.createErrorMessage('test', value);
-        }
-      })
+        },
+      }),
     });
 
     let object = setupObject(this, EmberObject.extend(Validations));
@@ -482,13 +476,13 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('null message object', function(assert) {
+  test('null message object', function (assert) {
     this.owner.register('validator:messages', DefaultMessages);
     let Validations = buildValidations({
       firstName: validator('presence', {
         presence: true,
-        message: null
-      })
+        message: null,
+      }),
     });
 
     let object = setupObject(this, EmberObject.extend(Validations));
@@ -499,16 +493,16 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('debounced validations', async function(assert) {
+  test('debounced validations', async function (assert) {
     let initSetup = true;
     let Validations = buildValidations({
       firstName: validator('inline', { validate: Validators.presence }),
       lastName: validator('inline', {
         validate: Validators.presence,
-        debounce: computed(function() {
+        debounce: computed(function () {
           return initSetup ? 0 : 500; // Do not debounce on initial object creation
-        }).volatile()
-      })
+        }).volatile(),
+      }),
     });
     let object = setupObject(this, EmberObject.extend(Validations));
 
@@ -554,13 +548,13 @@ module('Integration | Validations | Factory - General', function(hooks) {
     }, 505);
   });
 
-  test('debounced validator should only be called once', async function(assert) {
+  test('debounced validator should only be called once', async function (assert) {
     let count = 0;
     let Validations = buildValidations({
       firstName: validator('inline', {
         validate: () => count++,
-        debounce: 500
-      })
+        debounce: 500,
+      }),
     });
 
     let object = setupObject(this, EmberObject.extend(Validations));
@@ -579,27 +573,27 @@ module('Integration | Validations | Factory - General', function(hooks) {
     }, 505);
   });
 
-  test('debounced validations should cleanup on object destroy', function(assert) {
+  test('debounced validations should cleanup on object destroy', function (assert) {
     let done = assert.async();
     let initSetup = true;
 
     let debouncedValidator = validator('inline', {
-      debounce: computed(function() {
+      debounce: computed(function () {
         return initSetup ? 0 : 500;
       }).volatile(),
       validate(value, options, model, attr) {
         model.set('foo', 'bar');
         return Validators.presence(value, options, model, attr);
-      }
+      },
     });
 
     let Validations = buildValidations({
       firstName: validator('inline', { validate: Validators.presence }),
       lastName: debouncedValidator,
-      'details.url': debouncedValidator
+      'details.url': debouncedValidator,
     });
     let object = setupObject(this, EmberObject.extend(Validations), {
-      details: {}
+      details: {},
     });
 
     assert.equal(
@@ -633,7 +627,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     initSetup = false;
     object.setProperties({
       lastName: 'Golan',
-      'details.url': 'github.com'
+      'details.url': 'github.com',
     });
     assert.equal(object.get('validations.attrs.lastName.isValidating'), true);
     assert.equal(
@@ -654,13 +648,13 @@ module('Integration | Validations | Factory - General', function(hooks) {
     }, 200);
   });
 
-  test('disabled validations - simple', function(assert) {
+  test('disabled validations - simple', function (assert) {
     let Validations = buildValidations({
       firstName: validator('inline', { validate: Validators.presence }),
       lastName: validator('inline', {
         validate: Validators.presence,
-        disabled: true
-      })
+        disabled: true,
+      }),
     });
     let object = setupObject(this, EmberObject.extend(Validations));
 
@@ -693,19 +687,19 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.isValid'), true);
   });
 
-  test('disabled validations - cp with dependent key', function(assert) {
+  test('disabled validations - cp with dependent key', function (assert) {
     let Validations = buildValidations({
       firstName: validator('inline', { validate: Validators.presence }),
       lastName: validator('inline', {
         validate: Validators.presence,
-        disabled: not('model.validateLastName')
-      })
+        disabled: not('model.validateLastName'),
+      }),
     });
     let object = setupObject(
       this,
       EmberObject.extend(Validations, {
         firstName: 'Offir',
-        validateLastName: true
+        validateLastName: true,
       })
     );
 
@@ -739,7 +733,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.isValid'), true);
   });
 
-  test('attribute validation result options hash', function(assert) {
+  test('attribute validation result options hash', function (assert) {
     this.owner.register('validator:length', LengthValidator);
     this.owner.register('validator:presence', PresenceValidator);
 
@@ -750,15 +744,15 @@ module('Integration | Validations | Factory - General', function(hooks) {
           validator('inline', { validate: Validators.presence }),
           validator('inline', {
             validate: Validators.presence,
-            presence: true
+            presence: true,
           }),
           validator('presence', true),
           validator('length', {
             min: 1,
-            max: 5
-          })
-        ]
-      }
+            max: 5,
+          }),
+        ],
+      },
     });
     let object = setupObject(this, EmberObject.extend(Validations, { max: 5 }));
     let options = object.get('validations.attrs.firstName.options');
@@ -779,7 +773,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(options['inline'][0].description, 'First Name');
   });
 
-  test('attribute validation result options hash with cps', function(assert) {
+  test('attribute validation result options hash with cps', function (assert) {
     this.owner.register('validator:length', LengthValidator);
 
     let Validations = buildValidations({
@@ -787,10 +781,10 @@ module('Integration | Validations | Factory - General', function(hooks) {
         validators: [
           validator('length', {
             min: 1,
-            max: readOnly('model.max')
-          })
-        ]
-      }
+            max: readOnly('model.max'),
+          }),
+        ],
+      },
     });
     let object = setupObject(this, EmberObject.extend(Validations, { max: 5 }));
     let options = object.get('validations.attrs.firstName.options');
@@ -802,18 +796,18 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(options.length.max, 3);
   });
 
-  test('validations persist with inheritance', function(assert) {
+  test('validations persist with inheritance', function (assert) {
     let Parent = EmberObject.extend(
       buildValidations({
         firstName: validator('inline', { validate: Validators.presence }),
-        lastName: validator('inline', { validate: Validators.presence })
+        lastName: validator('inline', { validate: Validators.presence }),
       })
     );
 
     let Child = Parent.extend(
       buildValidations({
         middleName: validator('inline', { validate: Validators.presence }),
-        dob: validator('inline', { validate: Validators.presence })
+        dob: validator('inline', { validate: Validators.presence }),
       })
     );
 
@@ -830,39 +824,39 @@ module('Integration | Validations | Factory - General', function(hooks) {
 
     child.setProperties({
       middleName: 'John',
-      dob: '10/22/16'
+      dob: '10/22/16',
     });
 
     assert.equal(child.get('validations.errors.length'), 2);
 
     child.setProperties({
       firstName: 'Joe',
-      lastName: 'Jenkins'
+      lastName: 'Jenkins',
     });
 
     assert.equal(child.get('validations.isValid'), true);
     assert.equal(child.get('validations.errors.length'), 0);
   });
 
-  test('validations persist with deep inheritance', function(assert) {
+  test('validations persist with deep inheritance', function (assert) {
     let Parent = EmberObject.extend(
       buildValidations({
         firstName: validator('inline', { validate: Validators.presence }),
-        lastName: validator('inline', { validate: Validators.presence })
+        lastName: validator('inline', { validate: Validators.presence }),
       })
     );
 
     let Child = Parent.extend(
       buildValidations({
         middleName: validator('inline', { validate: Validators.presence }),
-        dob: validator('inline', { validate: Validators.presence })
+        dob: validator('inline', { validate: Validators.presence }),
       })
     );
 
     let Baby = Child.extend(
       buildValidations({
         diaper: validator('inline', { validate: Validators.presence }),
-        favParent: validator('inline', { validate: Validators.presence })
+        favParent: validator('inline', { validate: Validators.presence }),
       })
     );
 
@@ -880,40 +874,40 @@ module('Integration | Validations | Factory - General', function(hooks) {
         'middleName',
         'dob',
         'diaper',
-        'favParent'
+        'favParent',
       ].sort()
     );
 
     baby.setProperties({
       middleName: 'John',
-      dob: '10/22/16'
+      dob: '10/22/16',
     });
 
     assert.equal(baby.get('validations.errors.length'), 4);
 
     baby.setProperties({
       firstName: 'Joe',
-      lastName: 'Jenkins'
+      lastName: 'Jenkins',
     });
 
     assert.equal(baby.get('validations.errors.length'), 2);
 
     baby.setProperties({
       diaper: 'soiled',
-      favParent: 'mom'
+      favParent: 'mom',
     });
 
     assert.equal(baby.get('validations.isValid'), true);
     assert.equal(baby.get('validations.errors.length'), 0);
   });
 
-  test('nested keys - simple', function(assert) {
+  test('nested keys - simple', function (assert) {
     let Validations = buildValidations({
       'user.firstName': validator('inline', { validate: Validators.presence }),
-      'user.lastName': validator('inline', { validate: Validators.presence })
+      'user.lastName': validator('inline', { validate: Validators.presence }),
     });
     let object = setupObject(this, EmberObject.extend(Validations), {
-      user: {}
+      user: {},
     });
 
     assert.equal(object.get('validations.attrs.user.firstName.isValid'), false);
@@ -931,13 +925,13 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.isValid'), true);
   });
 
-  test('nested keys - complex', function(assert) {
+  test('nested keys - complex', function (assert) {
     let Validations = buildValidations({
       firstName: validator('inline', { validate: Validators.presence }),
       'user.foo.bar.baz': validator('inline', {
-        validate: Validators.presence
+        validate: Validators.presence,
       }),
-      'user.foo.boop': validator('inline', { validate: Validators.presence })
+      'user.foo.boop': validator('inline', { validate: Validators.presence }),
     });
     let object = setupObject(this, EmberObject.extend(Validations));
 
@@ -983,16 +977,16 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.notOk(object.get(`validations.attrs.user.foo.${ATTRS_MODEL}`));
   });
 
-  test('nested keys - inheritance', function(assert) {
+  test('nested keys - inheritance', function (assert) {
     let Parent = EmberObject.extend(
       buildValidations({
         firstName: validator('inline', { validate: Validators.presence }),
         'user.firstName': validator('inline', {
-          validate: Validators.presence
+          validate: Validators.presence,
         }),
         'user.middleName': validator('inline', {
-          validate: Validators.presence
-        })
+          validate: Validators.presence,
+        }),
       })
     );
 
@@ -1002,8 +996,8 @@ module('Integration | Validations | Factory - General', function(hooks) {
         'user.middleName': validator('inline', {
           validate() {
             return 'Middle name invalid';
-          }
-        })
+          },
+        }),
       })
     );
 
@@ -1022,8 +1016,8 @@ module('Integration | Validations | Factory - General', function(hooks) {
       user: {
         firstName: 'Offir',
         middleName: 'David',
-        lastName: 'Golan'
-      }
+        lastName: 'Golan',
+      },
     });
 
     assert.equal(child.get('validations.errors.length'), 2);
@@ -1033,7 +1027,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
 
     child.setProperties({
-      firstName: 'John'
+      firstName: 'John',
     });
 
     assert.equal(child.get('validations.isValid'), false);
@@ -1041,12 +1035,12 @@ module('Integration | Validations | Factory - General', function(hooks) {
   });
 
   // https://github.com/offirgolan/ember-cp-validations/pull/656
-  skip('call super in validations class with no super property', function(assert) {
+  skip('call super in validations class with no super property', function (assert) {
     // see https://github.com/offirgolan/ember-cp-validations/issues/149
     assert.expect(1);
 
     let Validations = buildValidations({
-      firstName: validator('inline', { validate: Validators.presence })
+      firstName: validator('inline', { validate: Validators.presence }),
     });
 
     let mixin = Mixin.create({
@@ -1056,38 +1050,39 @@ module('Integration | Validations | Factory - General', function(hooks) {
           // this is no __validationsClass__ method on the super, it is wrapped
           // with the closest context which is the 'foo' action
           assert.ok(false); // should not reach here
-        }
-      }
+        },
+      },
     });
 
     let controller = setupObject(
       this,
       Controller.extend(Validations, mixin, {
+        // eslint-disable-next-line ember/no-actions-hash
         actions: {
           foo() {
             assert.ok(true);
             /* eslint-disable */
             let validations = this.get('validations');
             /* eslint-enable */
-          }
-        }
+          },
+        },
       })
     );
 
     controller.send('foo');
   });
 
-  test('multiple mixins', function(assert) {
+  test('multiple mixins', function (assert) {
     let Validations1 = buildValidations({
-      firstName: validator('inline', { validate: Validators.presence })
+      firstName: validator('inline', { validate: Validators.presence }),
     });
 
     let Validations2 = buildValidations({
-      middleName: validator('inline', { validate: Validators.presence })
+      middleName: validator('inline', { validate: Validators.presence }),
     });
 
     let Validations3 = buildValidations({
-      lastName: validator('inline', { validate: Validators.presence })
+      lastName: validator('inline', { validate: Validators.presence }),
     });
 
     let object = setupObject(
@@ -1119,15 +1114,15 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.isValid'), true);
   });
 
-  test('validateAttribute - sync validations', function(assert) {
+  test('validateAttribute - sync validations', function (assert) {
     let Validations = buildValidations({
       firstName: [
         validator('inline', { validate: Validators.presence }),
-        validator('inline', { validate: () => true })
-      ]
+        validator('inline', { validate: () => true }),
+      ],
     });
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     return object
@@ -1140,19 +1135,19 @@ module('Integration | Validations | Factory - General', function(hooks) {
       });
   });
 
-  test('validateAttribute - async validations', function(assert) {
+  test('validateAttribute - async validations', function (assert) {
     let Validations = buildValidations({
       firstName: [
         validator('inline', {
-          validate: () => EmberPromise.resolve('firstName is invalid')
+          validate: () => EmberPromise.resolve('firstName is invalid'),
         }),
         validator('inline', {
-          validate: () => EmberPromise.resolve('firstName is really invalid')
-        })
-      ]
+          validate: () => EmberPromise.resolve('firstName is really invalid'),
+        }),
+      ],
     });
     let object = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     return object
@@ -1164,7 +1159,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
       });
   });
 
-  test('warning validators api', function(assert) {
+  test('warning validators api', function (assert) {
     this.owner.register('validator:length', LengthValidator);
     this.owner.register('validator:presence', PresenceValidator);
 
@@ -1175,23 +1170,23 @@ module('Integration | Validations | Factory - General', function(hooks) {
           validator('presence', {
             presence: true,
             isWarning: true,
-            message: '{description} should not be empty'
+            message: '{description} should not be empty',
           }),
           validator('length', {
             min: 4,
             isWarning: true,
-            message: '{description} is weak'
+            message: '{description} is weak',
           }),
           validator('length', {
             min: 1,
-            max: 10
-          })
-        ]
-      }
+            max: 10,
+          }),
+        ],
+      },
     });
 
     let object = setupObject(this, EmberObject.extend(Validations), {
-      password: ''
+      password: '',
     });
 
     assert.equal(object.get('validations.isValid'), false);
@@ -1227,7 +1222,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('computed isWarning option', function(assert) {
+  test('computed isWarning option', function (assert) {
     this.owner.register('validator:length', LengthValidator);
     this.owner.register('validator:presence', PresenceValidator);
 
@@ -1239,19 +1234,19 @@ module('Integration | Validations | Factory - General', function(hooks) {
           validator('presence', {
             presence: true,
             isWarning: readOnly('model.isWarning'),
-            message: '{description} should not be empty'
+            message: '{description} should not be empty',
           }),
           validator('length', {
             min: 1,
-            max: 10
-          })
-        ]
-      }
+            max: 10,
+          }),
+        ],
+      },
     });
 
     let object = setupObject(this, EmberObject.extend(Validations), {
       password: '',
-      isWarning: false
+      isWarning: false,
     });
 
     assert.equal(object.get('validations.isValid'), false);
@@ -1264,7 +1259,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(object.get('validations.errors.length'), 1);
   });
 
-  test('options CP changes trigger attribute revalidation', function(assert) {
+  test('options CP changes trigger attribute revalidation', function (assert) {
     this.owner.register('validator:length', LengthValidator);
 
     let Validations = buildValidations(
@@ -1273,13 +1268,13 @@ module('Integration | Validations | Factory - General', function(hooks) {
           description: readOnly('model.description'),
           validators: [
             validator('length', {
-              min: alias('model.minLength')
-            })
-          ]
-        }
+              min: alias('model.minLength'),
+            }),
+          ],
+        },
       },
       {
-        disabled: not('model.enabled')
+        disabled: not('model.enabled'),
       }
     );
 
@@ -1289,7 +1284,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
         enabled: true,
         description: 'First Name',
         minLength: 6,
-        firstName: 'Offir'
+        firstName: 'Offir',
       })
     );
 
@@ -1322,7 +1317,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
 
     object.setProperties({
       description: 'Name',
-      minLength: 10
+      minLength: 10,
     });
 
     assert.equal(object.get('validations.attrs.firstName.isValid'), false);
@@ -1341,7 +1336,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('lazy validators are actually lazy', function(assert) {
+  test('lazy validators are actually lazy', function (assert) {
     this.owner.register('validator:length', LengthValidator);
     this.owner.register('validator:presence', PresenceValidator);
 
@@ -1353,16 +1348,16 @@ module('Integration | Validations | Factory - General', function(hooks) {
         validators: [
           validator('presence', true),
           validator('length', {
-            min: 5
+            min: 5,
           }),
           validator('inline', {
             validate() {
               customValidatorCount++;
               return 'Password is not valid';
-            }
-          })
-        ]
-      }
+            },
+          }),
+        ],
+      },
     });
 
     let object = setupObject(this, EmberObject.extend(Validations));
@@ -1406,7 +1401,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(customValidatorCount, 1, 'Last validator only executed once');
   });
 
-  test('none lazy validators are actually not lazy', function(assert) {
+  test('none lazy validators are actually not lazy', function (assert) {
     this.owner.register('validator:length', LengthValidator);
     this.owner.register('validator:presence', PresenceValidator);
 
@@ -1419,17 +1414,17 @@ module('Integration | Validations | Factory - General', function(hooks) {
           validator('presence', true),
           validator('length', {
             min: 5,
-            lazy: false
+            lazy: false,
           }),
           validator('inline', {
             lazy: false,
             validate() {
               customValidatorCount++;
               return 'Password is not valid';
-            }
-          })
-        ]
-      }
+            },
+          }),
+        ],
+      },
     });
 
     let object = setupObject(this, EmberObject.extend(Validations));
@@ -1473,24 +1468,24 @@ module('Integration | Validations | Factory - General', function(hooks) {
     assert.equal(customValidatorCount, 3, 'Last validator executed 3 times');
   });
 
-  test('validator should return correct error type', function(assert) {
+  test('validator should return correct error type', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
     this.owner.register('validator:length', LengthValidator);
 
     let Validations = buildValidations({
       firstName: [
         validator('presence', true),
-        validator('length', { min: 5, max: 35 })
+        validator('length', { min: 5, max: 35 }),
       ],
       lastName: [
         validator('presence', true),
-        validator('length', { min: 5, max: 35 })
-      ]
+        validator('length', { min: 5, max: 35 }),
+      ],
     });
 
     let obj = setupObject(this, EmberObject.extend(Validations), {
       firstName: 'Foo',
-      lastName: null
+      lastName: null,
     });
 
     assert.equal(
@@ -1515,7 +1510,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('volatile validations should not recompute', function(assert) {
+  test('volatile validations should not recompute', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
     this.owner.register('validator:length', LengthValidator);
 
@@ -1526,19 +1521,19 @@ module('Integration | Validations | Factory - General', function(hooks) {
           dependentKeys: ['model.foo'],
           min: 5,
           max: 35,
-          volatile: true
-        })
-      ]
+          volatile: true,
+        }),
+      ],
     });
 
     let obj = setupObject(
       this,
       EmberObject.extend(Validations, {
         isInvalid: not('validations.attrs.firstName.isValid'),
-        isInvalidGlobal: not('validations.attrs.isValid')
+        isInvalidGlobal: not('validations.attrs.isValid'),
       }),
       {
-        firstName: null
+        firstName: null,
       }
     );
 
@@ -1582,7 +1577,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
     );
   });
 
-  test('load test', function(assert) {
+  test('load test', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
 
     let Validations = buildValidations({
@@ -1590,7 +1585,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
       b: validator('presence', true),
       c: validator('presence', true),
       d: validator('presence', true),
-      e: validator('presence', true)
+      e: validator('presence', true),
     });
 
     let Klass = EmberObject.extend(Validations, {
@@ -1598,7 +1593,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
       b: null,
       c: null,
       d: null,
-      e: null
+      e: null,
     });
 
     let items = A([]);
@@ -1608,7 +1603,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
         b: i,
         c: i,
         d: i,
-        e: i
+        e: i,
       });
       items.push(obj);
     }
@@ -1623,7 +1618,7 @@ module('Integration | Validations | Factory - General', function(hooks) {
         b: i + 1000,
         c: i + 1000,
         d: i + 1000,
-        e: i + 1000
+        e: i + 1000,
       });
     });
 

--- a/tests/integration/validations/model-relationships-test.js
+++ b/tests/integration/validations/model-relationships-test.js
@@ -3,7 +3,7 @@ import ArrayProxy from '@ember/array/proxy';
 import EmberObject from '@ember/object';
 import { isNone } from '@ember/utils';
 import { A as emberArray } from '@ember/array';
-import DS from 'ember-data';
+import { PromiseArray, PromiseObject } from '@ember-data/store/-private';
 import setupObject from '../../helpers/setup-object';
 import DefaultMessages from 'dummy/validators/messages';
 import BelongsToValidator from 'ember-cp-validations/validators/belongs-to';
@@ -20,48 +20,45 @@ const Validators = {
       return `${attr} should be present`;
     }
     return true;
-  }
+  },
 };
 
 const Validations = buildValidations({
   firstName: validator('inline', { validate: Validators.presence }),
-  lastName: validator('inline', { validate: Validators.presence })
+  lastName: validator('inline', { validate: Validators.presence }),
 });
 
 const BelongsToValidations = buildValidations({
-  friend: validator('belongs-to')
+  friend: validator('belongs-to'),
 });
 
 const HasManyValidations = buildValidations({
-  friends: validator('has-many')
+  friends: validator('has-many'),
 });
 
-module('Integration | Validations | Model Relationships', function(hooks) {
+module('Integration | Validations | Model Relationships', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.owner.register('validator:messages', DefaultMessages);
   });
 
-  test('belong to validation - no cycle', function(assert) {
+  test('belong to validation - no cycle', function (assert) {
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let user2 = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'John'
+      firstName: 'John',
     });
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: user2
+      friend: user2,
     });
 
     let { validations, model } = user.get('validations').validateSync();
 
     assert.equal(model, user, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['friend'].sort()
     );
 
@@ -72,7 +69,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(friend.get('message'), 'lastName should be present');
   });
 
-  test('belong to validation - with cycle', function(assert) {
+  test('belong to validation - with cycle', function (assert) {
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations));
@@ -82,10 +79,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
 
     assert.equal(model, user, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['friend'].sort()
     );
 
@@ -96,25 +90,22 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(friend.get('message'), undefined);
   });
 
-  test('has-many relationship is sync', function(assert) {
+  test('has-many relationship is sync', function (assert) {
     this.owner.register('validator:has-many', HasManyValidator);
 
     let friend = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'John'
+      firstName: 'John',
     });
 
     let user = setupObject(this, EmberObject.extend(HasManyValidations), {
-      friends: [friend]
+      friends: [friend],
     });
 
     let { validations, model } = user.get('validations').validateSync();
 
     assert.equal(model, user, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['friends'].sort()
     );
 
@@ -124,25 +115,22 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(friends.get('message'), 'lastName should be present');
   });
 
-  test('has-many relationship is sync with proxy', function(assert) {
+  test('has-many relationship is sync with proxy', function (assert) {
     this.owner.register('validator:has-many', HasManyValidator);
 
     let friend = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'John'
+      firstName: 'John',
     });
 
     let user = setupObject(this, EmberObject.extend(HasManyValidations), {
-      friends: ArrayProxy.create({ content: emberArray([friend]) })
+      friends: ArrayProxy.create({ content: emberArray([friend]) }),
     });
 
     let { validations, model } = user.get('validations').validateSync();
 
     assert.equal(model, user, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['friends'].sort()
     );
 
@@ -152,17 +140,17 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(friends.get('message'), 'lastName should be present');
   });
 
-  test('has-many relationship is async', function(assert) {
+  test('has-many relationship is async', function (assert) {
     this.owner.register('validator:has-many', HasManyValidator);
 
     let friend = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     let user = setupObject(this, EmberObject.extend(HasManyValidations), {
-      friends: new EmberPromise(resolve => {
+      friends: new EmberPromise((resolve) => {
         resolve([friend]);
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -172,10 +160,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friends'].sort()
       );
 
@@ -188,21 +173,21 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('has-many relationship is async and isWarning', function(assert) {
+  test('has-many relationship is async and isWarning', function (assert) {
     this.owner.register('validator:has-many', HasManyValidator);
 
     let HasManyValidations = buildValidations({
-      friends: validator('has-many', { isWarning: true })
+      friends: validator('has-many', { isWarning: true }),
     });
 
     let friend = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     let user = setupObject(this, EmberObject.extend(HasManyValidations), {
-      friends: new EmberPromise(resolve => {
+      friends: new EmberPromise((resolve) => {
         resolve([friend]);
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -212,10 +197,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friends'].sort()
       );
 
@@ -232,17 +214,17 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('belongs-to relationship is async', function(assert) {
+  test('belongs-to relationship is async', function (assert) {
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let friend = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: new EmberPromise(resolve => {
+      friend: new EmberPromise((resolve) => {
         resolve(friend);
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -252,10 +234,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friend'].sort()
       );
 
@@ -268,21 +247,21 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('belongs-to relationship is async and isWarning', function(assert) {
+  test('belongs-to relationship is async and isWarning', function (assert) {
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let BelongsToValidations = buildValidations({
-      friend: validator('belongs-to', { isWarning: true })
+      friend: validator('belongs-to', { isWarning: true }),
     });
 
     let friend = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: new EmberPromise(resolve => {
+      friend: new EmberPromise((resolve) => {
         resolve(friend);
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -292,10 +271,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friend'].sort()
       );
 
@@ -309,13 +285,13 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('belongs-to relationship is async and does not exist', function(assert) {
+  test('belongs-to relationship is async and does not exist', function (assert) {
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: new EmberPromise(resolve => {
+      friend: new EmberPromise((resolve) => {
         resolve();
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -325,10 +301,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friend'].sort()
       );
       assert.equal(user.get('validations.isValid'), true);
@@ -337,13 +310,13 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('has-many relationship is async and does not exist', function(assert) {
+  test('has-many relationship is async and does not exist', function (assert) {
     this.owner.register('validator:has-many', HasManyValidator);
 
     let user = setupObject(this, EmberObject.extend(HasManyValidations), {
-      friends: new EmberPromise(resolve => {
+      friends: new EmberPromise((resolve) => {
         resolve();
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -353,10 +326,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friends'].sort()
       );
       assert.equal(user.get('validations.isValid'), true);
@@ -365,13 +335,13 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('belongs-to relationship returns undefined', function(assert) {
+  test('belongs-to relationship returns undefined', function (assert) {
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: new EmberPromise(resolve => {
+      friend: new EmberPromise((resolve) => {
         resolve({}); // validations object will be undefined
-      })
+      }),
     });
 
     let validations = user.get('validations').validate();
@@ -381,10 +351,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     validations.then(({ model, validations }) => {
       assert.equal(model, user, 'expected model to be the correct model');
       assert.deepEqual(
-        validations
-          .get('content')
-          .getEach('attribute')
-          .sort(),
+        validations.get('content').getEach('attribute').sort(),
         ['friend'].sort()
       );
 
@@ -397,7 +364,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     return validations;
   });
 
-  test('alias validation - simple', function(assert) {
+  test('alias validation - simple', function (assert) {
     this.owner.register('validator:alias', AliasValidator);
 
     let user = setupObject(
@@ -406,7 +373,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
         buildValidations({
           firstName: validator('inline', { validate: Validators.presence }),
           lastName: validator('inline', { validate: Validators.presence }),
-          fullName: validator('alias', 'firstName')
+          fullName: validator('alias', 'firstName'),
         })
       )
     );
@@ -440,7 +407,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(user.get('validations.attrs.fullName.isValid'), true);
   });
 
-  test('alias validation - firstMessageOnly', function(assert) {
+  test('alias validation - firstMessageOnly', function (assert) {
     this.owner.register('validator:alias', AliasValidator);
 
     let user = setupObject(
@@ -450,12 +417,12 @@ module('Integration | Validations | Model Relationships', function(hooks) {
           {
             firstName: [
               validator('inline', { validate: () => 'First error message' }),
-              validator('inline', { validate: () => 'Second error message' })
+              validator('inline', { validate: () => 'Second error message' }),
             ],
             fullName: validator('alias', {
               alias: 'firstName',
-              firstMessageOnly: true
-            })
+              firstMessageOnly: true,
+            }),
           },
           { lazy: false }
         )
@@ -476,7 +443,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     );
   });
 
-  test('alias validation - multiple', function(assert) {
+  test('alias validation - multiple', function (assert) {
     this.owner.register('validator:alias', AliasValidator);
 
     let user = setupObject(
@@ -488,8 +455,8 @@ module('Integration | Validations | Model Relationships', function(hooks) {
             lastName: validator('inline', { validate: Validators.presence }),
             fullName: [
               validator('alias', 'firstName'),
-              validator('alias', 'lastName')
-            ]
+              validator('alias', 'lastName'),
+            ],
           },
           { lazy: false }
         )
@@ -526,25 +493,22 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(user.get('validations.attrs.fullName.isValid'), true);
   });
 
-  test('presence on empty DS.PromiseObject', function(assert) {
+  test('presence on empty PromiseObject', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
 
     let Validations = buildValidations({
-      friend: validator('presence', true)
+      friend: validator('presence', true),
     });
 
     let user = setupObject(this, EmberObject.extend(Validations), {
-      friend: DS.PromiseObject.create()
+      friend: PromiseObject.create(),
     });
 
     let { validations, model } = user.get('validations').validateSync();
 
     assert.equal(model, user, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['friend'].sort()
     );
 
@@ -554,25 +518,22 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(friend.get('message'), "This field can't be blank");
   });
 
-  test('presence on empty DS.PromiseArray', function(assert) {
+  test('presence on empty PromiseArray', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
 
     let Validations = buildValidations({
-      friends: validator('presence', true)
+      friends: validator('presence', true),
     });
 
     let user = setupObject(this, EmberObject.extend(Validations), {
-      friends: DS.PromiseArray.create()
+      friends: PromiseArray.create(),
     });
 
     let { validations, model } = user.get('validations').validateSync();
 
     assert.equal(model, user, 'expected model to be the correct model');
     assert.deepEqual(
-      validations
-        .get('content')
-        .getEach('attribute')
-        .sort(),
+      validations.get('content').getEach('attribute').sort(),
       ['friends'].sort()
     );
 
@@ -582,21 +543,21 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     assert.equal(friends.get('message'), "This field can't be blank");
   });
 
-  test('debounce should work across nested HasMany relationships', function(assert) {
+  test('debounce should work across nested HasMany relationships', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
     this.owner.register('validator:has-many', HasManyValidator);
 
     let done = assert.async();
 
     let FriendValidations = buildValidations({
-      name: validator('presence', { presence: true, debounce: 50 })
+      name: validator('presence', { presence: true, debounce: 50 }),
     });
 
     let friend = setupObject(this, EmberObject.extend(FriendValidations));
     let user = setupObject(this, EmberObject.extend(HasManyValidations), {
-      friends: new EmberPromise(resolve => {
+      friends: new EmberPromise((resolve) => {
         resolve([friend]);
-      })
+      }),
     });
 
     user
@@ -647,22 +608,22 @@ module('Integration | Validations | Model Relationships', function(hooks) {
       });
   });
 
-  test('debounce should work across nested BelongsTo relationships', function(assert) {
+  test('debounce should work across nested BelongsTo relationships', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
     let done = assert.async();
 
     let FriendValidations = buildValidations({
-      name: validator('presence', { presence: true, debounce: 50 })
+      name: validator('presence', { presence: true, debounce: 50 }),
     });
 
     let friend = setupObject(this, EmberObject.extend(FriendValidations));
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: new EmberPromise(resolve => {
+      friend: new EmberPromise((resolve) => {
         resolve(friend);
-      })
+      }),
     });
 
     user
@@ -713,7 +674,7 @@ module('Integration | Validations | Model Relationships', function(hooks) {
       });
   });
 
-  test('Validations should work across two-way BelongsTo relationships', function(assert) {
+  test('Validations should work across two-way BelongsTo relationships', function (assert) {
     this.owner.register('validator:presence', PresenceValidator);
     this.owner.register('validator:belongs-to', BelongsToValidator);
 
@@ -722,14 +683,14 @@ module('Integration | Validations | Model Relationships', function(hooks) {
     let user2 = setupObject(this, EmberObject.extend(BelongsToValidations));
 
     let user = setupObject(this, EmberObject.extend(BelongsToValidations), {
-      friend: new EmberPromise(resolve => {
+      friend: new EmberPromise((resolve) => {
         resolve(user2);
-      })
+      }),
     });
 
     user2.set(
       'friend',
-      new EmberPromise(resolve => {
+      new EmberPromise((resolve) => {
         resolve(user);
       })
     );

--- a/tests/integration/validators/composable-test.js
+++ b/tests/integration/validators/composable-test.js
@@ -10,17 +10,17 @@ import { setupTest } from 'ember-qunit';
 import { Promise } from 'rsvp';
 
 const ComposedValidations = buildValidations({
-  value: validator('composed')
+  value: validator('composed'),
 });
 
-module('Integration | Validators | Composable', function(hooks) {
+module('Integration | Validators | Composable', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.owner.register('validator:messages', DefaultMessages);
   });
 
-  test('Composability - simple', function(assert) {
+  test('Composability - simple', function (assert) {
     assert.expect(5);
 
     this.owner.register('validator:presence', PresenceValidator);
@@ -29,12 +29,12 @@ module('Integration | Validators | Composable', function(hooks) {
       BaseValidator.extend({
         validate(value) {
           return this.test('presence', value, { presence: true });
-        }
+        },
       })
     );
 
     const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
-      value: ''
+      value: '',
     });
 
     assert.equal(obj.get('validations.isValid'), false);
@@ -47,7 +47,7 @@ module('Integration | Validators | Composable', function(hooks) {
     assert.equal(obj.get('validations.isValidating'), false);
   });
 
-  test('Composability - multiple', function(assert) {
+  test('Composability - multiple', function (assert) {
     assert.expect(8);
 
     this.owner.register('validator:presence', PresenceValidator);
@@ -69,12 +69,12 @@ module('Integration | Validators | Composable', function(hooks) {
           }
 
           return true;
-        }
+        },
       })
     );
 
     const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
-      value: ''
+      value: '',
     });
 
     assert.equal(obj.get('validations.isValid'), false);
@@ -96,7 +96,7 @@ module('Integration | Validators | Composable', function(hooks) {
     assert.equal(obj.get('validations.isValidating'), false);
   });
 
-  test('Composability - async', async function(assert) {
+  test('Composability - async', async function (assert) {
     assert.expect(8);
 
     this.owner.register(
@@ -106,7 +106,7 @@ module('Integration | Validators | Composable', function(hooks) {
           return Promise.resolve(
             value.includes('foo') ? true : 'Must include foo!'
           );
-        }
+        },
       })
     );
 
@@ -117,7 +117,7 @@ module('Integration | Validators | Composable', function(hooks) {
           return Promise.reject(
             value.includes('bar') ? true : 'Must include bar!'
           );
-        }
+        },
       })
     );
 
@@ -138,12 +138,12 @@ module('Integration | Validators | Composable', function(hooks) {
           }
 
           return true;
-        }
+        },
       })
     );
 
     const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
-      value: ''
+      value: '',
     });
 
     await obj.validate();
@@ -166,12 +166,12 @@ module('Integration | Validators | Composable', function(hooks) {
     assert.equal(obj.get('validations.isValidating'), false);
   });
 
-  test('Composability - unsupported types', function(assert) {
+  test('Composability - unsupported types', function (assert) {
     const unsupportedTypes = ['alias', 'belongs-to', 'dependent', 'has-many'];
 
     assert.expect(unsupportedTypes.length);
 
-    unsupportedTypes.forEach(type =>
+    unsupportedTypes.forEach((type) =>
       this.owner.register(`validator:${type}`, BaseValidator)
     );
 
@@ -180,21 +180,21 @@ module('Integration | Validators | Composable', function(hooks) {
       BaseValidator.extend({
         validate(type) {
           this.test(type);
-        }
+        },
       })
     );
 
     const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
-      value: ''
+      value: '',
     });
 
-    unsupportedTypes.forEach(type => {
+    unsupportedTypes.forEach((type) => {
       obj.set('value', type);
       assert.throws(() => obj.validateSync(), new RegExp(type));
     });
   });
 
-  test('Validators get cached', function(assert) {
+  test('Validators get cached', function (assert) {
     assert.expect(3);
 
     this.owner.register('validator:presence', PresenceValidator);
@@ -202,7 +202,7 @@ module('Integration | Validators | Composable', function(hooks) {
       'validator:composed',
       BaseValidator.extend({
         validate(value) {
-          const cache = this.get('_testValidatorCache');
+          const cache = this._testValidatorCache;
 
           assert.notOk(cache.presence);
 
@@ -214,12 +214,12 @@ module('Integration | Validators | Composable', function(hooks) {
           this.test('presence', value, { presence: false });
 
           assert.equal(presenceValidator, cache.presence);
-        }
+        },
       })
     );
 
     const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
-      value: ''
+      value: '',
     });
 
     obj.validateSync();

--- a/tests/unit/utils/assign-test.js
+++ b/tests/unit/utils/assign-test.js
@@ -2,34 +2,41 @@ import EmberObject, { computed } from '@ember/object';
 import { module, test } from 'qunit';
 import deepSet from 'ember-cp-validations/utils/deep-set';
 
-module('Unit | Utils | deepSet', function() {
-  test('single level', function(assert) {
+module('Unit | Utils | deepSet', function () {
+  test('single level', function (assert) {
     let obj = {};
     deepSet(obj, 'foo.bar', 1);
     assert.deepEqual(obj, { foo: { bar: 1 } });
   });
 
-  test('single level - ember object', function(assert) {
+  test('single level - ember object', function (assert) {
     let obj = EmberObject.create();
     deepSet(obj, 'foo.bar', 1, true);
     assert.ok(obj.foo instanceof EmberObject);
     assert.equal(obj.get('foo.bar'), 1);
   });
 
-  test('single level - ember object w/ CP', function(assert) {
+  test('single level - ember object w/ CP', function (assert) {
     let obj = EmberObject.create();
-    deepSet(obj, 'foo.bar', computed(() => 1), true);
+    deepSet(
+      obj,
+      'foo.bar',
+      computed(function () {
+        return 1;
+      }),
+      true
+    );
     assert.ok(obj.foo instanceof EmberObject);
     assert.equal(obj.get('foo.bar'), 1);
   });
 
-  test('multi level', function(assert) {
+  test('multi level', function (assert) {
     let obj = {};
     deepSet(obj, 'foo.bar.baz.boo', 1);
     assert.deepEqual(obj, { foo: { bar: { baz: { boo: 1 } } } });
   });
 
-  test('multi level - ember object', function(assert) {
+  test('multi level - ember object', function (assert) {
     let obj = EmberObject.create();
     deepSet(obj, 'foo.bar.baz.boo', 1, true);
     assert.ok(obj.foo.bar.baz instanceof EmberObject);

--- a/tests/unit/utils/flatten-test.js
+++ b/tests/unit/utils/flatten-test.js
@@ -1,15 +1,18 @@
 import { module, test } from 'qunit';
 import { flatten } from 'ember-cp-validations/utils/array';
 
-module('Unit | Utils | array:flatten', function() {
-  test('flattens an array of arrays', function(assert) {
+module('Unit | Utils | array:flatten', function () {
+  test('flattens an array of arrays', function (assert) {
     let result = flatten([[1], [2, 3], [4, 5]]);
 
     assert.deepEqual(result, [1, 2, 3, 4, 5]);
   });
 
-  test('flattens an array of arrays of arrays ;P', function(assert) {
-    let result = flatten([[[1], [2, 3]], [4, 5]]);
+  test('flattens an array of arrays of arrays ;P', function (assert) {
+    let result = flatten([
+      [[1], [2, 3]],
+      [4, 5],
+    ]);
 
     assert.deepEqual(result, [1, 2, 3, 4, 5]);
   });

--- a/tests/unit/utils/get-with-default-test.js
+++ b/tests/unit/utils/get-with-default-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import getWithDefault from 'ember-cp-validations/utils/get-with-default';
 
-module('Unit | Utils | get with default', function() {
-  test('return the default value when value is undefined', function(assert) {
+module('Unit | Utils | get with default', function () {
+  test('return the default value when value is undefined', function (assert) {
     const undefinedObj = {
-      foo: undefined
+      foo: undefined,
     };
     const defaultValue = 'something';
     let result = getWithDefault(undefinedObj, 'foo', defaultValue);
@@ -12,9 +12,9 @@ module('Unit | Utils | get with default', function() {
     assert.equal(result, defaultValue);
   });
 
-  test('return the correct value if defined', function(assert) {
+  test('return the correct value if defined', function (assert) {
     const obj = {
-      yehuda: 'katz'
+      yehuda: 'katz',
     };
 
     const defaultValue = 'something';

--- a/tests/unit/utils/should-call-super-test.js
+++ b/tests/unit/utils/should-call-super-test.js
@@ -2,29 +2,32 @@ import EmberObject, { computed } from '@ember/object';
 import { module, test } from 'qunit';
 import shouldCallSuper from 'ember-cp-validations/utils/should-call-super';
 
-module('Unit | Utils | shouldCallSuper', function() {
-  test('shouldCallSuper - true', function(assert) {
+module('Unit | Utils | shouldCallSuper', function () {
+  test('shouldCallSuper - true', function (assert) {
     let Parent = EmberObject.extend({
-      foo: computed(function() {})
+      // eslint-disable-next-line ember/require-return-from-computed
+      foo: computed(function () {}),
     });
 
     let Child = Parent.extend({
-      foo: computed(function() {
+      // eslint-disable-next-line ember/require-return-from-computed
+      foo: computed(function () {
         assert.ok(shouldCallSuper(this, 'foo'));
-      })
+      }),
     });
 
     let child = Child.create();
     child.get('foo');
   });
 
-  test('shouldCallSuper - false', function(assert) {
+  test('shouldCallSuper - false', function (assert) {
     let Parent = EmberObject.extend();
 
     let Child = Parent.extend({
-      foo: computed(function() {
+      // eslint-disable-next-line ember/require-return-from-computed
+      foo: computed(function () {
         assert.ok(!shouldCallSuper(this, 'foo'));
-      })
+      }),
     });
 
     let child = Child.create();

--- a/tests/unit/validations/ds-model-test.js
+++ b/tests/unit/validations/ds-model-test.js
@@ -2,10 +2,10 @@ import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Validations | DS.Model', function(hooks) {
+module('Unit | Validations | DS.Model', function (hooks) {
   setupTest(hooks);
 
-  test('create model with defaults', function(assert) {
+  test('create model with defaults', function (assert) {
     let object = run(() =>
       this.owner.lookup('service:store').createRecord('signup')
     );
@@ -27,7 +27,7 @@ module('Unit | Validations | DS.Model', function(hooks) {
     );
   });
 
-  test('create model overriding defaults', function(assert) {
+  test('create model overriding defaults', function (assert) {
     let object = run(() =>
       this.owner
         .lookup('service:store')

--- a/tests/unit/validations/ember-proxy-test.js
+++ b/tests/unit/validations/ember-proxy-test.js
@@ -4,16 +4,16 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { Validations } from 'dummy/models/company';
 
-module('Unit | Validations | Ember ObjectProxy', function(hooks) {
+module('Unit | Validations | Ember ObjectProxy', function (hooks) {
   setupTest(hooks);
 
-  test('extend ObjectProxy with validations', function(assert) {
+  test('extend ObjectProxy with validations', function (assert) {
     run(() => {
       let company = this.owner.lookup('service:store').createRecord('company');
 
       const container = this.owner.ownerInjection();
       const proxy = ObjectProxy.extend(Validations).create(container, {
-        content: company
+        content: company,
       });
 
       assert.notOk(proxy.get('validations.isValid'));

--- a/tests/unit/validations/nested-model-relationship-test.js
+++ b/tests/unit/validations/nested-model-relationship-test.js
@@ -2,10 +2,10 @@ import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Validations | Nested Model Relationships', function(hooks) {
+module('Unit | Validations | Nested Model Relationships', function (hooks) {
   setupTest(hooks);
 
-  test('order with invalid question shows invalid', function(assert) {
+  test('order with invalid question shows invalid', function (assert) {
     assert.expect(11);
     let order = run(() =>
       this.owner
@@ -21,16 +21,16 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       orderSelection = store.createRecord('order-selection', {
         order,
         line: orderLine,
-        quantity: 1
+        quantity: 1,
       });
       orderSelectionQuestion = store.createRecord('order-selection-question', {
         order,
-        selection: orderSelection
+        selection: orderSelection,
       });
       store.createRecord('order-selection-question', {
         order,
         selection: orderSelection,
-        text: 'foo'
+        text: 'foo',
       });
     });
 
@@ -104,7 +104,7 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       });
   });
 
-  test('order with valid question shows valid', function(assert) {
+  test('order with valid question shows valid', function (assert) {
     assert.expect(11);
     let order = run(() =>
       this.owner
@@ -120,12 +120,12 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       orderSelection = store.createRecord('order-selection', {
         order,
         line: orderLine,
-        quantity: 1
+        quantity: 1,
       });
       orderSelectionQuestion = store.createRecord('order-selection-question', {
         order,
         selection: orderSelection,
-        text: 'answer'
+        text: 'answer',
       });
     });
 
@@ -199,7 +199,7 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       });
   });
 
-  test('order with invalid question shows invalid if validated in reverse order', function(assert) {
+  test('order with invalid question shows invalid if validated in reverse order', function (assert) {
     assert.expect(11);
     let order = run(() =>
       this.owner
@@ -215,11 +215,11 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       orderSelection = store.createRecord('order-selection', {
         order,
         line: orderLine,
-        quantity: 1
+        quantity: 1,
       });
       orderSelectionQuestion = store.createRecord('order-selection-question', {
         order,
-        selection: orderSelection
+        selection: orderSelection,
       });
     });
 
@@ -293,7 +293,7 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       });
   });
 
-  test('order with valid question shows valid if validated in reverse order', function(assert) {
+  test('order with valid question shows valid if validated in reverse order', function (assert) {
     assert.expect(11);
     let order = run(() =>
       this.owner
@@ -309,12 +309,12 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       orderSelection = store.createRecord('order-selection', {
         order,
         line: orderLine,
-        quantity: 1
+        quantity: 1,
       });
       orderSelectionQuestion = store.createRecord('order-selection-question', {
         order,
         selection: orderSelection,
-        text: 'answer'
+        text: 'answer',
       });
     });
 
@@ -388,7 +388,7 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       });
   });
 
-  test('order with invalid question shows valid if invalid question is deleted in reverse order', function(assert) {
+  test('order with invalid question shows valid if invalid question is deleted in reverse order', function (assert) {
     assert.expect(9);
     let order = run(() =>
       this.owner
@@ -403,7 +403,7 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
 
     let store = this.owner.lookup('service:store');
     run(() => {
-      let fakeSave = function(model) {
+      let fakeSave = function (model) {
         model.get('_internalModel').adapterWillCommit();
         model.get('_internalModel').adapterDidCommit();
       };
@@ -411,24 +411,24 @@ module('Unit | Validations | Nested Model Relationships', function(hooks) {
       orderLine = store.createRecord('order-line', {
         id: 1,
         order,
-        type: 'item'
+        type: 'item',
       });
       orderSelection = store.createRecord('order-selection', {
         id: 1,
         order,
         line: orderLine,
-        quantity: 1
+        quantity: 1,
       });
       orderSelectionQuestion = store.createRecord('order-selection-question', {
         id: 1,
         order,
         selection: orderSelection,
-        text: 'answer'
+        text: 'answer',
       });
       orderSelectionQuestion2 = store.createRecord('order-selection-question', {
         id: 2,
         order,
-        selection: orderSelection
+        selection: orderSelection,
       });
 
       fakeSave(order);

--- a/tests/unit/validators/base-test.js
+++ b/tests/unit/validators/base-test.js
@@ -8,56 +8,56 @@ import setupObject from '../../helpers/setup-object';
 
 let defaultOptions, options, validator, message;
 
-module('Unit | Validator | base', function(hooks) {
+module('Unit | Validator | base', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = setupObject(this, BaseValidator);
   });
 
-  test('buildOptions - merge all options', function(assert) {
+  test('buildOptions - merge all options', function (assert) {
     assert.expect(1);
 
     options = {
-      foo: 'a'
+      foo: 'a',
     };
 
     defaultOptions = {
-      bar: 'b'
+      bar: 'b',
     };
 
     options = validator.buildOptions(options, defaultOptions);
     assert.deepEqual(options.getProperties(['foo', 'bar']), {
       foo: 'a',
-      bar: 'b'
+      bar: 'b',
     });
   });
 
-  test('buildOptions - does not overwrite options', function(assert) {
+  test('buildOptions - does not overwrite options', function (assert) {
     assert.expect(1);
 
     options = {
       foo: 'a',
-      bar: 'b'
+      bar: 'b',
     };
 
     defaultOptions = {
-      bar: 'c'
+      bar: 'c',
     };
 
     options = validator.buildOptions(options, defaultOptions);
     assert.deepEqual(options.getProperties(['foo', 'bar']), {
       foo: 'a',
-      bar: 'b'
+      bar: 'b',
     });
   });
 
-  test('buildOptions - toObject', function(assert) {
+  test('buildOptions - toObject', function (assert) {
     assert.expect(4);
 
     options = validator.buildOptions({
       foo: alias('bar'),
-      bar: 'bar'
+      bar: 'bar',
     });
 
     assert.ok(options instanceof EmberObject);
@@ -69,26 +69,26 @@ module('Unit | Validator | base', function(hooks) {
     assert.equal(optionsObj.foo, 'bar');
   });
 
-  test('createErrorMessage - message function', function(assert) {
+  test('createErrorMessage - message function', function (assert) {
     assert.expect(1);
 
     options = {
       message() {
         return '{description} has some sort of error';
-      }
+      },
     };
 
     message = validator.createErrorMessage(undefined, undefined, options);
     assert.equal(message, 'This field has some sort of error');
   });
 
-  test('value - default gets model value', function(assert) {
+  test('value - default gets model value', function (assert) {
     assert.expect(2);
 
     validator.setProperties({
       model: EmberObject.create({ foo: 'bar' }),
       attribute: 'foo',
-      options: {}
+      options: {},
     });
 
     validator.init();
@@ -97,7 +97,7 @@ module('Unit | Validator | base', function(hooks) {
     assert.equal(validator.getValue(), 'bar');
   });
 
-  test('value - overwrite value method via options', function(assert) {
+  test('value - overwrite value method via options', function (assert) {
     assert.expect(3);
 
     validator.setProperties({
@@ -105,9 +105,9 @@ module('Unit | Validator | base', function(hooks) {
       attribute: 'foo',
       options: {
         value() {
-          return this.get('model.bar');
-        }
-      }
+          return this.model.bar;
+        },
+      },
     });
 
     validator.init();
@@ -117,11 +117,11 @@ module('Unit | Validator | base', function(hooks) {
     assert.notOk(validator.get('options.value'));
   });
 
-  test('message - handles SafeString', function(assert) {
+  test('message - handles SafeString', function (assert) {
     assert.expect(1);
 
     options = {
-      message: htmlSafe('should be more than &euro;15')
+      message: htmlSafe('should be more than &euro;15'),
     };
 
     message = validator.createErrorMessage(undefined, undefined, options);

--- a/tests/unit/validators/collection-test.js
+++ b/tests/unit/validators/collection-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | collection', function(hooks) {
+module('Unit | Validator | collection', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:collection');
   });
 
-  test('buildOptions', function(assert) {
+  test('buildOptions', function (assert) {
     assert.expect(2);
 
     options = true;
@@ -23,7 +23,7 @@ module('Unit | Validator | collection', function(hooks) {
     assert.equal(builtOptions.get('collection'), true);
   });
 
-  test('value is collection', function(assert) {
+  test('value is collection', function (assert) {
     assert.expect(1);
 
     options = { collection: true };
@@ -33,7 +33,7 @@ module('Unit | Validator | collection', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('value not collection', function(assert) {
+  test('value not collection', function (assert) {
     assert.expect(1);
 
     options = { collection: true };
@@ -43,7 +43,7 @@ module('Unit | Validator | collection', function(hooks) {
     assert.equal(message, 'This field must be a collection');
   });
 
-  test('singular - value is singular', function(assert) {
+  test('singular - value is singular', function (assert) {
     assert.expect(1);
 
     options = { collection: false };
@@ -53,7 +53,7 @@ module('Unit | Validator | collection', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('singular - value not singular', function(assert) {
+  test('singular - value not singular', function (assert) {
     assert.expect(1);
 
     options = { collection: false };

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -4,21 +4,21 @@ import { setupTest } from 'ember-qunit';
 
 let model, options, builtOptions, validator, message;
 
-module('Unit | Validator | confirmation', function(hooks) {
+module('Unit | Validator | confirmation', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:confirmation');
   });
 
-  test('attribute', function(assert) {
+  test('attribute', function (assert) {
     assert.expect(2);
 
     options = { on: 'email' };
     builtOptions = validator.buildOptions(options);
 
     model = EmberObject.create({
-      email: 'foo@gmail.com'
+      email: 'foo@gmail.com',
     });
 
     message = validator.validate(

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | date', function(hooks) {
+module('Unit | Validator | date', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:date');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     options = {};
@@ -18,12 +18,12 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('allow blank', function(assert) {
+  test('allow blank', function (assert) {
     assert.expect(2);
 
     options = {
       allowBlank: true,
-      before: '1/1/2015'
+      before: '1/1/2015',
     };
 
     builtOptions = validator.buildOptions(options);
@@ -35,7 +35,7 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, 'This field must be before January 1, 2015');
   });
 
-  test('valid date', function(assert) {
+  test('valid date', function (assert) {
     assert.expect(2);
 
     options = {};
@@ -49,11 +49,11 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('valid input date format', function(assert) {
+  test('valid input date format', function (assert) {
     assert.expect(2);
 
     options = {
-      format: { dateStyle: 'long' }
+      format: { dateStyle: 'long' },
     };
 
     builtOptions = validator.buildOptions(options);
@@ -65,12 +65,12 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, 'This field must be a valid date');
   });
 
-  test('error date format', function(assert) {
+  test('error date format', function (assert) {
     assert.expect(1);
 
     options = {
       errorFormat: { dateStyle: 'long' },
-      before: '1/1/2015'
+      before: '1/1/2015',
     };
 
     builtOptions = validator.buildOptions(options);
@@ -79,11 +79,11 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, 'This field must be before January 1, 2015');
   });
 
-  test('before', function(assert) {
+  test('before', function (assert) {
     assert.expect(2);
 
     options = {
-      before: '1/1/2015'
+      before: '1/1/2015',
     };
 
     builtOptions = validator.buildOptions(options);
@@ -95,11 +95,11 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('before or on', function(assert) {
+  test('before or on', function (assert) {
     assert.expect(3);
 
     options = {
-      onOrBefore: '1/1/2015'
+      onOrBefore: '1/1/2015',
     };
 
     builtOptions = validator.buildOptions(options);
@@ -114,11 +114,11 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('after', function(assert) {
+  test('after', function (assert) {
     assert.expect(2);
 
     options = {
-      after: '1/1/2015'
+      after: '1/1/2015',
     };
 
     builtOptions = validator.buildOptions(options);
@@ -130,11 +130,11 @@ module('Unit | Validator | date', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('after or on', function(assert) {
+  test('after or on', function (assert) {
     assert.expect(3);
 
     options = {
-      onOrAfter: '1/1/2015'
+      onOrAfter: '1/1/2015',
     };
 
     builtOptions = validator.buildOptions(options);

--- a/tests/unit/validators/dependent-test.js
+++ b/tests/unit/validators/dependent-test.js
@@ -1,4 +1,4 @@
-import EmberObject, { get } from '@ember/object';
+import EmberObject from '@ember/object';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
@@ -8,21 +8,21 @@ let Validator, message, model, options, builtOptions;
 
 let Validations = buildValidations({
   firstName: validator('presence', true),
-  lastName: validator('presence', true)
+  lastName: validator('presence', true),
 });
 
 let defaultOptions = {
-  on: ['firstName', 'lastName']
+  on: ['firstName', 'lastName'],
 };
 
-module('Unit | Validator | dependent', function(hooks) {
+module('Unit | Validator | dependent', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     Validator = this.owner.lookup('validator:dependent');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     builtOptions = Validator.buildOptions({}).toObject();
@@ -34,7 +34,7 @@ module('Unit | Validator | dependent', function(hooks) {
     }
   });
 
-  test('all empty attributes', function(assert) {
+  test('all empty attributes', function (assert) {
     assert.expect(4);
 
     options = defaultOptions;
@@ -42,50 +42,50 @@ module('Unit | Validator | dependent', function(hooks) {
 
     model = setupObject(this, EmberObject.extend(Validations));
 
-    assert.equal(get(model, 'validations.isValid'), false);
+    assert.equal(model.validations.isValid, false);
 
     message = Validator.validate(undefined, builtOptions.toObject(), model);
 
     assert.equal(message, 'This field is invalid');
-    assert.equal(get(model, 'validations.messages.length'), 1);
-    assert.equal(get(model, 'validations.isValid'), false);
+    assert.equal(model.validations.messages.length, 1);
+    assert.equal(model.validations.isValid, false);
   });
 
-  test('one dependent error', function(assert) {
+  test('one dependent error', function (assert) {
     assert.expect(4);
 
     options = defaultOptions;
     builtOptions = Validator.buildOptions(options);
 
     model = setupObject(this, EmberObject.extend(Validations), {
-      firstName: 'Offir'
+      firstName: 'Offir',
     });
 
-    assert.equal(get(model, 'validations.isValid'), false);
+    assert.equal(model.validations.isValid, false);
 
     message = Validator.validate(undefined, builtOptions.toObject(), model);
 
     assert.equal(message, 'This field is invalid');
-    assert.equal(get(model, 'validations.messages.length'), 1);
-    assert.equal(get(model, 'validations.isValid'), false);
+    assert.equal(model.validations.messages.length, 1);
+    assert.equal(model.validations.isValid, false);
   });
 
-  test('no dependent errors', function(assert) {
+  test('no dependent errors', function (assert) {
     assert.expect(4);
     options = defaultOptions;
     builtOptions = Validator.buildOptions(options);
 
     model = setupObject(this, EmberObject.extend(Validations), {
       firstName: 'Offir',
-      lastName: 'Golan'
+      lastName: 'Golan',
     });
 
-    assert.equal(get(model, 'validations.isValid'), true);
+    assert.equal(model.validations.isValid, true);
 
     message = Validator.validate(undefined, builtOptions.toObject(), model);
 
     assert.equal(message, true);
-    assert.equal(get(model, 'validations.messages.length'), 0);
-    assert.equal(get(model, 'validations.isValid'), true);
+    assert.equal(model.validations.messages.length, 0);
+    assert.equal(model.validations.isValid, true);
   });
 });

--- a/tests/unit/validators/ds-error-test.js
+++ b/tests/unit/validators/ds-error-test.js
@@ -1,18 +1,18 @@
 import EmberObject from '@ember/object';
-import DS from 'ember-data';
+import { Errors } from '@ember-data/model/-private';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 let model, validator, message;
 
-module('Unit | Validator | ds-error', function(hooks) {
+module('Unit | Validator | ds-error', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:ds-error');
   });
 
-  test('works with empty object', function(assert) {
+  test('works with empty object', function (assert) {
     assert.expect(1);
 
     model = EmberObject.create();
@@ -21,12 +21,12 @@ module('Unit | Validator | ds-error', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('it works', function(assert) {
+  test('it works', function (assert) {
     assert.expect(2);
 
     model = EmberObject.create({
-      errors: DS.Errors.create(),
-      username: null
+      errors: Errors.create(),
+      username: null,
     });
 
     message = validator.validate(undefined, undefined, model, 'username');
@@ -38,12 +38,12 @@ module('Unit | Validator | ds-error', function(hooks) {
     assert.equal(message, 'Username is not unique');
   });
 
-  test('gets last message', function(assert) {
+  test('gets last message', function (assert) {
     assert.expect(2);
 
     model = EmberObject.create({
-      errors: DS.Errors.create(),
-      username: null
+      errors: Errors.create(),
+      username: null,
     });
 
     message = validator.validate(undefined, undefined, model, 'username');

--- a/tests/unit/validators/exclusion-test.js
+++ b/tests/unit/validators/exclusion-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | exclusion', function(hooks) {
+module('Unit | Validator | exclusion', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:exclusion');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     builtOptions = validator.buildOptions({}).toObject();
@@ -22,12 +22,12 @@ module('Unit | Validator | exclusion', function(hooks) {
     }
   });
 
-  test('allow blank', function(assert) {
+  test('allow blank', function (assert) {
     assert.expect(2);
 
     options = {
       allowBlank: true,
-      in: ['foo', 'bar', 'baz']
+      in: ['foo', 'bar', 'baz'],
     };
 
     builtOptions = validator.buildOptions(options);
@@ -39,11 +39,11 @@ module('Unit | Validator | exclusion', function(hooks) {
     assert.equal(message, 'This field is reserved');
   });
 
-  test('not in array', function(assert) {
+  test('not in array', function (assert) {
     assert.expect(4);
 
     options = {
-      in: ['foo', 'bar', 'baz']
+      in: ['foo', 'bar', 'baz'],
     };
 
     builtOptions = validator.buildOptions(options);
@@ -61,11 +61,11 @@ module('Unit | Validator | exclusion', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('not in range', function(assert) {
+  test('not in range', function (assert) {
     assert.expect(5);
 
     options = {
-      range: [1, 10]
+      range: [1, 10],
     };
 
     builtOptions = validator.buildOptions(options);
@@ -86,11 +86,11 @@ module('Unit | Validator | exclusion', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('range type check - number', function(assert) {
+  test('range type check - number', function (assert) {
     assert.expect(4);
 
     options = {
-      range: [1, 10]
+      range: [1, 10],
     };
 
     builtOptions = validator.buildOptions(options);
@@ -108,11 +108,11 @@ module('Unit | Validator | exclusion', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('range type check - string', function(assert) {
+  test('range type check - string', function (assert) {
     assert.expect(4);
 
     options = {
-      range: ['a', 'z']
+      range: ['a', 'z'],
     };
 
     builtOptions = validator.buildOptions(options);

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | format', function(hooks) {
+module('Unit | Validator | format', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:format');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     builtOptions = validator.buildOptions({}).toObject();
@@ -22,12 +22,12 @@ module('Unit | Validator | format', function(hooks) {
     }
   });
 
-  test('allow blank', function(assert) {
+  test('allow blank', function (assert) {
     assert.expect(2);
 
     options = {
       allowBlank: true,
-      type: 'email'
+      type: 'email',
     };
     options = validator.buildOptions(options, {}).toObject();
 
@@ -38,7 +38,7 @@ module('Unit | Validator | format', function(hooks) {
     assert.equal(message, 'This field must be a valid email address');
   });
 
-  test('email no option', function(assert) {
+  test('email no option', function (assert) {
     let validAddresses = [
       'email@domain.com',
       'firstname.lastname@domain.com',
@@ -50,7 +50,7 @@ module('Unit | Validator | format', function(hooks) {
       'email@domain.name',
       'email@domain.co.jp',
       'firstname-lastname@domain.com',
-      'EMAIL@DOMAIN.COM'
+      'EMAIL@DOMAIN.COM',
     ];
     let invalidAddresses = [
       'plainaddress',
@@ -74,25 +74,25 @@ module('Unit | Validator | format', function(hooks) {
       'email@domain.com-',
       'email@domain.com-.',
       'email@-domain.com',
-      'email@domain..com'
+      'email@domain..com',
     ];
 
     assert.expect(validAddresses.length + invalidAddresses.length);
 
     options = {
-      type: 'email'
+      type: 'email',
     };
 
     options = validator.buildOptions(options, {}).toObject();
 
-    validAddresses.forEach(email =>
+    validAddresses.forEach((email) =>
       assert.equal(
         validator.validate(email, options),
         true,
         `validation of ${email} must succeed`
       )
     );
-    invalidAddresses.forEach(email =>
+    invalidAddresses.forEach((email) =>
       assert.equal(
         validator.validate(email, options),
         'This field must be a valid email address',
@@ -101,7 +101,7 @@ module('Unit | Validator | format', function(hooks) {
     );
   });
 
-  test('email option allowNonTld', function(assert) {
+  test('email option allowNonTld', function (assert) {
     let validAddresses = [
       'email@domain.com',
       'firstname.lastname@domain.com',
@@ -114,7 +114,7 @@ module('Unit | Validator | format', function(hooks) {
       'email@domain.co.jp',
       'firstname-lastname@domain.com',
       'EMAIL@DOMAIN.COM',
-      'email@domain'
+      'email@domain',
     ];
     let invalidAddresses = [
       'plainaddress',
@@ -137,26 +137,26 @@ module('Unit | Validator | format', function(hooks) {
       'email@domain.com-',
       'email@domain.com-.',
       'email@-domain.com',
-      'email@domain..com'
+      'email@domain..com',
     ];
 
     assert.expect(validAddresses.length + invalidAddresses.length);
 
     options = {
       type: 'email',
-      allowNonTld: true
+      allowNonTld: true,
     };
 
     options = validator.buildOptions(options, {}).toObject();
 
-    validAddresses.forEach(email =>
+    validAddresses.forEach((email) =>
       assert.equal(
         validator.validate(email, options),
         true,
         `validation of ${email} must succeed`
       )
     );
-    invalidAddresses.forEach(email =>
+    invalidAddresses.forEach((email) =>
       assert.equal(
         validator.validate(email, options),
         'This field must be a valid email address',
@@ -165,11 +165,11 @@ module('Unit | Validator | format', function(hooks) {
     );
   });
 
-  test('phone', function(assert) {
+  test('phone', function (assert) {
     assert.expect(2);
 
     options = {
-      type: 'phone'
+      type: 'phone',
     };
 
     options = validator.buildOptions(options, {}).toObject();
@@ -181,11 +181,11 @@ module('Unit | Validator | format', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('url', function(assert) {
+  test('url', function (assert) {
     assert.expect(2);
 
     options = {
-      type: 'url'
+      type: 'url',
     };
 
     options = validator.buildOptions(options, {}).toObject();
@@ -197,11 +197,11 @@ module('Unit | Validator | format', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('custom', function(assert) {
+  test('custom', function (assert) {
     assert.expect(2);
 
     options = {
-      regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,8}$/
+      regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,8}$/,
     };
 
     options = validator.buildOptions(options, {}).toObject();

--- a/tests/unit/validators/inclusion-test.js
+++ b/tests/unit/validators/inclusion-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | inclusion', function(hooks) {
+module('Unit | Validator | inclusion', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:inclusion');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     builtOptions = validator.buildOptions({}).toObject();
@@ -22,12 +22,12 @@ module('Unit | Validator | inclusion', function(hooks) {
     }
   });
 
-  test('allow blank', function(assert) {
+  test('allow blank', function (assert) {
     assert.expect(2);
 
     options = {
       allowBlank: true,
-      in: ['foo', 'bar', 'baz']
+      in: ['foo', 'bar', 'baz'],
     };
     builtOptions = validator.buildOptions(options);
 
@@ -38,11 +38,11 @@ module('Unit | Validator | inclusion', function(hooks) {
     assert.equal(message, 'This field is not included in the list');
   });
 
-  test('in array', function(assert) {
+  test('in array', function (assert) {
     assert.expect(4);
 
     options = {
-      in: ['foo', 'bar', 'baz']
+      in: ['foo', 'bar', 'baz'],
     };
     builtOptions = validator.buildOptions(options);
 
@@ -59,11 +59,11 @@ module('Unit | Validator | inclusion', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('in range', function(assert) {
+  test('in range', function (assert) {
     assert.expect(5);
 
     options = {
-      range: [1, 10]
+      range: [1, 10],
     };
     builtOptions = validator.buildOptions(options);
 
@@ -83,11 +83,11 @@ module('Unit | Validator | inclusion', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('range type check - number', function(assert) {
+  test('range type check - number', function (assert) {
     assert.expect(7);
 
     options = {
-      range: [1, 10]
+      range: [1, 10],
     };
     builtOptions = validator.buildOptions(options);
 
@@ -113,11 +113,11 @@ module('Unit | Validator | inclusion', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('range type check - string', function(assert) {
+  test('range type check - string', function (assert) {
     assert.expect(5);
 
     options = {
-      range: ['a', 'z']
+      range: ['a', 'z'],
     };
     builtOptions = validator.buildOptions(options);
 

--- a/tests/unit/validators/inline-test.js
+++ b/tests/unit/validators/inline-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Validator | inline', function(hooks) {
+module('Unit | Validator | inline', function (hooks) {
   setupTest(hooks);
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     try {
@@ -14,26 +14,27 @@ module('Unit | Validator | inline', function(hooks) {
     }
   });
 
-  test('it works', function(assert) {
+  test('it works', function (assert) {
     assert.expect(3);
 
-     const ValidatorClass = typeof this.owner.factoryFor === 'function'
-      ? this.owner.factoryFor('validator:inline')
-      : this.owner.resolveRegistration('validator:inline');
+    const ValidatorClass =
+      typeof this.owner.factoryFor === 'function'
+        ? this.owner.factoryFor('validator:inline')
+        : this.owner.resolveRegistration('validator:inline');
 
     const validator = ValidatorClass.create({
-        options: {
-          foo: 'bar',
-          validate(value, options) {
-            assert.equal(this, validator, 'Context is preserved');
-            assert.equal(options.foo, 'bar', 'It receives options');
-            assert.notOk(
-              options.validate,
-              'Validate fn removed from the options'
-            );
-          },
+      options: {
+        foo: 'bar',
+        validate(value, options) {
+          assert.equal(this, validator, 'Context is preserved');
+          assert.equal(options.foo, 'bar', 'It receives options');
+          assert.notOk(
+            options.validate,
+            'Validate fn removed from the options'
+          );
         },
-      });
+      },
+    });
 
     validator.validate('foo', validator.get('options').toObject());
   });

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | length', function(hooks) {
+module('Unit | Validator | length', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:length');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(1);
 
     builtOptions = validator.buildOptions({});
@@ -19,12 +19,12 @@ module('Unit | Validator | length', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('allow blank', function(assert) {
+  test('allow blank', function (assert) {
     assert.expect(2);
 
     options = {
       allowBlank: true,
-      min: 5
+      min: 5,
     };
 
     builtOptions = validator.buildOptions(options);
@@ -36,7 +36,7 @@ module('Unit | Validator | length', function(hooks) {
     assert.equal(message, 'This field is too short (minimum is 5 characters)');
   });
 
-  test('allow none', function(assert) {
+  test('allow none', function (assert) {
     assert.expect(2);
 
     options = {
@@ -55,11 +55,11 @@ module('Unit | Validator | length', function(hooks) {
     assert.equal(message, 'This field is invalid');
   });
 
-  test('is', function(assert) {
+  test('is', function (assert) {
     assert.expect(2);
 
     options = {
-      is: 4
+      is: 4,
     };
 
     builtOptions = validator.buildOptions(options);
@@ -74,11 +74,11 @@ module('Unit | Validator | length', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('min', function(assert) {
+  test('min', function (assert) {
     assert.expect(2);
 
     options = {
-      min: 5
+      min: 5,
     };
 
     builtOptions = validator.buildOptions(options);
@@ -90,11 +90,11 @@ module('Unit | Validator | length', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('max', function(assert) {
+  test('max', function (assert) {
     assert.expect(2);
 
     options = {
-      max: 5
+      max: 5,
     };
 
     builtOptions = validator.buildOptions(options);
@@ -106,11 +106,11 @@ module('Unit | Validator | length', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('array', function(assert) {
+  test('array', function (assert) {
     assert.expect(2);
 
     options = {
-      min: 1
+      min: 1,
     };
 
     builtOptions = validator.buildOptions(options);

--- a/tests/unit/validators/messages-test.js
+++ b/tests/unit/validators/messages-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let messages;
 
-module('Unit | Validator | messages', function(hooks) {
+module('Unit | Validator | messages', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     messages = this.owner.lookup('validator:messages');
   });
 
-  test('message strings present', function(assert) {
+  test('message strings present', function (assert) {
     assert.expect(2);
     assert.equal(messages.get('invalid'), '{description} is invalid');
     assert.equal(
@@ -19,10 +19,10 @@ module('Unit | Validator | messages', function(hooks) {
     );
   });
 
-  test('formatMessage', function(assert) {
+  test('formatMessage', function (assert) {
     assert.expect(3);
     let context = {
-      description: 'This field'
+      description: 'This field',
     };
     assert.equal(
       messages.formatMessage(undefined, context),
@@ -36,17 +36,17 @@ module('Unit | Validator | messages', function(hooks) {
       messages.formatMessage('{foo} {foo} {bar} {baz}', {
         foo: 'a',
         bar: 1,
-        baz: 'abc'
+        baz: 'abc',
       }),
       'a a 1 abc'
     );
   });
 
-  test('getMessageFor', function(assert) {
+  test('getMessageFor', function (assert) {
     assert.expect(2);
     let context = {
       description: 'This field',
-      min: 4
+      min: 4,
     };
     assert.equal(
       messages.getMessageFor('foo', context),

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | number', function(hooks) {
+module('Unit | Validator | number', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:number');
   });
 
-  test('no options', function(assert) {
+  test('no options', function (assert) {
     assert.expect(2);
 
     builtOptions = validator.buildOptions({});
@@ -22,11 +22,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('allow string', function(assert) {
+  test('allow string', function (assert) {
     assert.expect(6);
 
     options = {
-      allowString: true
+      allowString: true,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -52,11 +52,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, 'This field must be a number');
   });
 
-  test('integer', function(assert) {
+  test('integer', function (assert) {
     assert.expect(3);
 
     options = {
-      integer: true
+      integer: true,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -70,11 +70,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, 'This field must be an integer');
   });
 
-  test('is', function(assert) {
+  test('is', function (assert) {
     assert.expect(2);
 
     options = {
-      is: 22
+      is: 22,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -85,11 +85,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('lt', function(assert) {
+  test('lt', function (assert) {
     assert.expect(3);
 
     options = {
-      lt: 22
+      lt: 22,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -103,11 +103,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, 'This field must be less than 22');
   });
 
-  test('lte', function(assert) {
+  test('lte', function (assert) {
     assert.expect(3);
 
     options = {
-      lte: 22
+      lte: 22,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -121,11 +121,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, 'This field must be less than or equal to 22');
   });
 
-  test('gt', function(assert) {
+  test('gt', function (assert) {
     assert.expect(3);
 
     options = {
-      gt: 22
+      gt: 22,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -139,11 +139,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('gte', function(assert) {
+  test('gte', function (assert) {
     assert.expect(3);
 
     options = {
-      gte: 22
+      gte: 22,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -157,11 +157,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('positive', function(assert) {
+  test('positive', function (assert) {
     assert.expect(4);
 
     options = {
-      positive: true
+      positive: true,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -178,11 +178,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('odd', function(assert) {
+  test('odd', function (assert) {
     assert.expect(4);
 
     options = {
-      odd: true
+      odd: true,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -199,11 +199,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('even', function(assert) {
+  test('even', function (assert) {
     assert.expect(5);
 
     options = {
-      even: true
+      even: true,
     };
     builtOptions = validator.buildOptions(options);
 
@@ -223,11 +223,11 @@ module('Unit | Validator | number', function(hooks) {
     assert.equal(message, 'This field must be even');
   });
 
-  test('allowBlank', function(assert) {
+  test('allowBlank', function (assert) {
     assert.expect(3);
 
     options = {
-      allowBlank: true
+      allowBlank: true,
     };
     builtOptions = validator.buildOptions(options);
 

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 
 let options, builtOptions, validator, message;
 
-module('Unit | Validator | presence', function(hooks) {
+module('Unit | Validator | presence', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     validator = this.owner.lookup('validator:presence');
   });
 
-  test('buildOptions', function(assert) {
+  test('buildOptions', function (assert) {
     assert.expect(2);
 
     options = true;
@@ -22,7 +22,7 @@ module('Unit | Validator | presence', function(hooks) {
     assert.equal(builtOptions.get('presence'), true);
   });
 
-  test('presence - value present', function(assert) {
+  test('presence - value present', function (assert) {
     assert.expect(1);
 
     options = { presence: true };
@@ -33,7 +33,7 @@ module('Unit | Validator | presence', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('presence - value blank', function(assert) {
+  test('presence - value blank', function (assert) {
     assert.expect(1);
 
     options = { presence: true };
@@ -44,7 +44,7 @@ module('Unit | Validator | presence', function(hooks) {
     assert.equal(message, true);
   });
 
-  test('presence with ignoreBlank - value blank', function(assert) {
+  test('presence with ignoreBlank - value blank', function (assert) {
     assert.expect(1);
 
     options = { presence: true, ignoreBlank: true };
@@ -55,7 +55,7 @@ module('Unit | Validator | presence', function(hooks) {
     assert.equal(message, "This field can't be blank");
   });
 
-  test('presence - value not present', function(assert) {
+  test('presence - value not present', function (assert) {
     assert.expect(1);
 
     options = { presence: true };
@@ -65,7 +65,7 @@ module('Unit | Validator | presence', function(hooks) {
     assert.equal(message, "This field can't be blank");
   });
 
-  test('absence - value present', function(assert) {
+  test('absence - value present', function (assert) {
     assert.expect(1);
 
     options = { presence: false };
@@ -75,7 +75,7 @@ module('Unit | Validator | presence', function(hooks) {
     assert.equal(message, 'This field must be blank');
   });
 
-  test('absence - value not present', function(assert) {
+  test('absence - value not present', function (assert) {
     assert.expect(1);
 
     options = { presence: false };


### PR DESCRIPTION
Part of the effort of making `@qonto/ember-cp-validations` Ember 4 compatible, aiming to bring code style consistency for the upcoming changes required to achieve this goal. It does not take any further steps in terms of fixing every outdated Ember idioms, only what's been reported by ESLint is the subject of this PR.

 - Enables ESLint/Prettier that were previously ignored `/*` on purpose
 - Fixes all manually- & auto-fixable lint issues
 - Allows importing private Ember Data modules in tests (addon space is clean) - since these exports exist in Ember 4+, there is no reason to rush for a replacement _at this moment_
 - Ignores a few rules like:
   - Classic classes, since the whole addon is written that way (`ember/no-classic-classes`)
   - Creating new mixins, same reason (`ember/no-new-mixins`)
   - Linting against volatile CPs - they're gonna be deal with later through deprecations (`ember/no-volatile-computed-properties`)