### PR TITLE
Fix all deprecations except `computed-property.volatile` & `ember-global`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-cli-terser": "^4.0.1",
     "ember-cli-yuidoc": "^0.8.8",
     "ember-code-snippet": "^3.0.0",
-    "ember-data": "~3.25.0",
+    "ember-data": "~3.28.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-font-awesome": "^3.0.5",
@@ -75,7 +75,7 @@
     "ember-source": "~3.28.8",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.18.1",
-    "ember-test-selectors": "^0.3.8",
+    "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "2.0.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.20.0",
@@ -125,7 +125,8 @@
   },
   "resolutions": {
     "**/ember-cli-babel": "> 7.0.0",
-    "**/@embroider/macros": "^1.0.0"
+    "**/@embroider/macros": "^1.0.0",
+    "**/@embroider/util": "^1.6.0"
   },
   "homepage": "https://github.com/offirgolan/ember-cp-validations",
   "volta": {

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -3,12 +3,12 @@ self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'ember-global' },
-    { handler: 'silence', matchId: 'ember.component.reopen' },
+    { handler: 'throw', matchId: 'ember.component.reopen' },
     {
-      handler: 'silence',
+      handler: 'throw',
       matchId: 'deprecated-run-loop-and-computed-dot-access',
     },
     { handler: 'silence', matchId: 'computed-property.volatile' },
-    { handler: 'silence', matchId: 'this-property-fallback' },
+    { handler: 'throw', matchId: 'this-property-fallback' },
   ],
 };

--- a/tests/integration/helpers/v-get-test.js
+++ b/tests/integration/helpers/v-get-test.js
@@ -30,27 +30,27 @@ module('Integration | Helper | v-get', function (hooks) {
   test('it renders', async function (assert) {
     assert.expect(1);
 
-    await render(hbs`{{v-get model 'isValid'}}`);
+    await render(hbs`{{v-get this.model 'isValid'}}`);
     assert.dom(this.element).hasText('false');
   });
 
   test('access attribute validations', async function (assert) {
     assert.expect(3);
 
-    await render(hbs`{{v-get model 'username' 'isValid'}}`);
+    await render(hbs`{{v-get this.model 'username' 'isValid'}}`);
     assert.dom(this.element).hasText('false');
 
-    await render(hbs`{{v-get model 'username' 'message'}}`);
+    await render(hbs`{{v-get this.model 'username' 'message'}}`);
     assert.dom(this.element).hasText('This field is invalid');
 
-    await render(hbs`{{v-get model 'email' 'isValid'}}`);
+    await render(hbs`{{v-get this.model 'email' 'isValid'}}`);
     assert.dom(this.element).hasText('true');
   });
 
   test('updating validation should rerender', async function (assert) {
     assert.expect(2);
 
-    await render(hbs`{{v-get model 'username' 'isValid'}}`);
+    await render(hbs`{{v-get this.model 'username' 'isValid'}}`);
     assert.dom(this.element).hasText('false');
 
     this.set('model.validations.attrs.username.isValid', true);
@@ -62,7 +62,7 @@ module('Integration | Helper | v-get', function (hooks) {
     assert.expect(2);
 
     await render(hbs`
-      {{#if (v-get model 'email' 'isValid')}}
+      {{#if (v-get this.model 'email' 'isValid')}}
         Email address is valid
       {{/if}}
     `);
@@ -70,8 +70,8 @@ module('Integration | Helper | v-get', function (hooks) {
     assert.dom(this.element).hasText('Email address is valid');
 
     await render(hbs`
-      {{#unless (v-get model 'username' 'isValid')}}
-        {{v-get model 'username' 'message'}}
+      {{#unless (v-get this.model 'username' 'isValid')}}
+        {{v-get this.model 'username' 'message'}}
       {{/unless}}
     `);
 
@@ -82,7 +82,7 @@ module('Integration | Helper | v-get', function (hooks) {
     assert.expect(2);
 
     await render(
-      hbs`<button type="button" disabled={{v-get model 'isInvalid'}}>Button</button>`
+      hbs`<button type="button" disabled={{v-get this.model 'isInvalid'}}>Button</button>`
     );
 
     assert.dom(this.element).hasText('Button');
@@ -93,7 +93,7 @@ module('Integration | Helper | v-get', function (hooks) {
     assert.expect(3);
 
     await render(
-      hbs`<span class="base {{if (v-get model 'isInvalid') 'has-error'}}">Text</span>`
+      hbs`<span class="base {{if (v-get this.model 'isInvalid') 'has-error'}}">Text</span>`
     );
 
     assert.dom(this.element).hasText('Text');
@@ -108,11 +108,11 @@ module('Integration | Helper | v-get', function (hooks) {
   test('access validations with named args', async function (assert) {
     assert.expect(2);
 
-    await render(hbs`{{named-v-get model=model field='isValid'}}`);
+    await render(hbs`{{named-v-get model=this.model field='isValid'}}`);
     assert.dom(this.element).hasText('false');
 
     await render(
-      hbs`{{named-v-get model=model attr='username' field='isValid'}}`
+      hbs`{{named-v-get model=this.model attr='username' field='isValid'}}`
     );
     assert.dom(this.element).hasText('false');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,78 +1095,79 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-data/adapter@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.25.0.tgz#1138098a2d6633be0bc96181eb796465d7290860"
-  integrity sha512-CJEQmETO33lOrIazlSdFz0A42DCP66VOx4GhgP5erXBQqywn9O4TcR/ZE0oLXasjqHmcT6/4r+aZY8gnjrovjQ==
+"@ember-data/adapter@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.28.9.tgz#5d8121b7ed36a875ff2fa06f84d0ce6b6aa7b0d7"
+  integrity sha512-qcqTXfHq/TZjNyyCBCE11zQHbR6pc7FaMXKxhwgNyk1FYIFMe07IZgX2B9A2Y+famjxoOv780dn0dBQtWFihBg==
   dependencies:
-    "@ember-data/private-build-infra" "3.25.0"
-    "@ember-data/store" "3.25.0"
+    "@ember-data/private-build-infra" "3.28.9"
+    "@ember-data/store" "3.28.9"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/string" "^1.0.0"
-    ember-cli-babel "^7.18.0"
+    "@ember/string" "^3.0.0"
+    ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/canary-features@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.25.0.tgz#4712bcbdc50aa65ff380c24b12d21e178ef3b4fb"
-  integrity sha512-Wrf4oFOnsSjCb3iXEWwfZFvD6MLLztbq0oArw7ic5Fg/UJ4f1vo5tj8UunZjhjC34QKFuCeYgiAod7RL5158gA==
+"@ember-data/canary-features@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.28.9.tgz#08a302e2062fd02647432b49775edabfc55e2e9a"
+  integrity sha512-xvkZcdm2/jk0NjAIfBZMAMLwaCInJtZoIF2WjiIe4Q9So/deeTR7uhF+K7UlYQiVnyZWrTl5duvcGBrjzeNnnQ==
   dependencies:
-    ember-cli-babel "^7.18.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/debug@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.25.0.tgz#81f6168479a558a1fb4ddef754c35f8a6f125530"
-  integrity sha512-UEOau2jc8xQGYJ3Ty+Qxg1dbe8Dp8ko6CmghKGCbiNea/ouT+7WdAMreKKRoYR5m53gfbFJbR30t3Qb2eYolRQ==
+"@ember-data/debug@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.28.9.tgz#8d4d2eff29a86b3380684deceaf0dcf3cb422687"
+  integrity sha512-OoyAVjv/bv6CVrzuHpNFvYN1GEio42kq3NdaHwobqhQlD7ERP6KbkJj3XBI9SEgAjQIM4hFul+nO8BKNGF+tnw==
   dependencies:
-    "@ember-data/private-build-infra" "3.25.0"
+    "@ember-data/private-build-infra" "3.28.9"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/string" "^1.0.0"
-    ember-cli-babel "^7.18.0"
+    "@ember/string" "^3.0.0"
+    ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/model@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.25.0.tgz#1cf4ba95039701ee04e176f6073e114b5ab5f4f0"
-  integrity sha512-xanNW78p+2xYWWsRvwPyVv/TiNbsJ6qterFGtbD63lD1YO7WbGtrRYblxeXKRNcaaTzlrPdJVGZ8HK3NjoFVNg==
+"@ember-data/model@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.28.9.tgz#7cc05f7c53677076299362dbf2fc1abde9aae28d"
+  integrity sha512-B4yHxfcD8XWT1SCBBXHXJxNYauXvSFCO3K41m+QZlxzSzK+hrctsESgzCYE08MAG1t8qA3XlKDSxA+VNokovGA==
   dependencies:
-    "@ember-data/canary-features" "3.25.0"
-    "@ember-data/private-build-infra" "3.25.0"
-    "@ember-data/store" "3.25.0"
+    "@ember-data/canary-features" "3.28.9"
+    "@ember-data/private-build-infra" "3.28.9"
+    "@ember-data/store" "3.28.9"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/string" "^1.0.0"
-    ember-cli-babel "^7.18.0"
+    "@ember/string" "^3.0.0"
+    ember-cached-decorator-polyfill "^0.1.4"
+    ember-cli-babel "^7.26.6"
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
     ember-compatibility-helpers "^1.2.0"
-    inflection "1.12.0"
+    inflection "~1.13.1"
 
-"@ember-data/private-build-infra@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.25.0.tgz#8310fdb57685ad6e73cd80c5c8b8869722f4d4a6"
-  integrity sha512-KgWi7/CHzbkeUo2qNfSJbl0kxaUqgmYPrlL8FNcU7vR8VDvw94GNlYvgw1sY29h/7ieWHUphkCbGpXZuInTGvw==
+"@ember-data/private-build-infra@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.28.9.tgz#b556d3620dcd8d2999db2b22a6b006ccac5dd64d"
+  integrity sha512-QfwiNSAolXrIReNjqZZCyO3lG9d0cA+9WxR4jKU89aJy2++V1fpmCU/o33tmWKmpMdJ2TwO4nbRR4yLb6EtygA==
   dependencies:
     "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.25.0"
+    "@ember-data/canary-features" "3.28.9"
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-debug "^0.6.5"
     broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^2.0.2"
+    broccoli-funnel "^3.0.3"
     broccoli-merge-trees "^4.2.0"
-    broccoli-rollup "^4.1.1"
+    broccoli-rollup "^5.0.0"
     calculate-cache-key-for-tree "^2.0.0"
     chalk "^4.0.0"
-    ember-cli-babel "^7.18.0"
+    ember-cli-babel "^7.26.6"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^3.1.3"
+    ember-cli-typescript "^4.1.0"
     ember-cli-version-checker "^5.1.1"
     esm "^3.2.25"
     git-repo-info "^2.1.1"
@@ -1177,48 +1178,47 @@
     semver "^7.1.3"
     silent-error "^1.1.1"
 
-"@ember-data/record-data@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.25.0.tgz#b7cc96512023f1dc0f22e78ce08565c2e0899808"
-  integrity sha512-E601HjdrmD71qStqzfg64tMDBHDcOd4PWzabiWSNmv+Nxk5+Wa0WqxmsyMK7gTIAAdCQa7P9gaIO+//QOYZ9pg==
+"@ember-data/record-data@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.28.9.tgz#ac93b49c9096f6dd2825a38534c71d01e036f195"
+  integrity sha512-PZwR0FVjy7uSJpBtsfSJHJqApNagcytjbO+22XmegnQt/e6BZKBimDry4WfJTqg8qlhCS0v2Wsk2FCvpvO0bCQ==
   dependencies:
-    "@ember-data/canary-features" "3.25.0"
-    "@ember-data/private-build-infra" "3.25.0"
-    "@ember-data/store" "3.25.0"
+    "@ember-data/canary-features" "3.28.9"
+    "@ember-data/private-build-infra" "3.28.9"
+    "@ember-data/store" "3.28.9"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^4.0.0"
-    ember-cli-babel "^7.18.0"
+    ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-data/serializer@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.25.0.tgz#fb4291dbcf46313d5195c9f28126da22c806196e"
-  integrity sha512-FU0uUZLuIgsijWocafweL+NEPUcu+5p26GPnuQKLDKnoSUe70sYNUdhDLo9QfKx5I90SMdkdiJZxNXXRLqBDDA==
+"@ember-data/serializer@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.28.9.tgz#003e19cc1e0d44c6890de84b65b9a3f2a667d1cc"
+  integrity sha512-IoA6N1kh6yCq5cPUxnxW5WgedbEF6dPf1CGq7WWHVPfUI3+rpfAAyr5/EIxXqeHvQ5a5J4MOTyio+8xPn16KPQ==
   dependencies:
-    "@ember-data/private-build-infra" "3.25.0"
-    "@ember-data/store" "3.25.0"
-    ember-cli-babel "^7.18.0"
+    "@ember-data/private-build-infra" "3.28.9"
+    "@ember-data/store" "3.28.9"
+    ember-cli-babel "^7.26.6"
     ember-cli-test-info "^1.0.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-typescript "^4.1.0"
 
-"@ember-data/store@3.25.0":
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.25.0.tgz#26210ff7c8fb3a9ec67a88d1e65fec8e414b1a52"
-  integrity sha512-Dyk3KN4jJpofV02Ctp8z6SlXG07Vz5GP4fZsdc25ECm0Sayf48YXb6g2wnd+sSplc6qnyeCXx4znXLQtgivJsg==
+"@ember-data/store@3.28.9":
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.28.9.tgz#3467815bc94107698a1808a294f7360519ac6aa1"
+  integrity sha512-5yg/VdrhCcz+cOTsW38FGlW5kzf6Wm1Q8jsdUAEaDTVf716xjl3E7QkcOQxZbaFr5mEO2TvG53x8CUm/VseKbw==
   dependencies:
-    "@ember-data/canary-features" "3.25.0"
-    "@ember-data/private-build-infra" "3.25.0"
-    "@ember/string" "^1.0.0"
-    ember-cli-babel "^7.18.0"
+    "@ember-data/canary-features" "3.28.9"
+    "@ember-data/private-build-infra" "3.28.9"
+    "@ember/string" "^3.0.0"
+    "@glimmer/tracking" "^1.0.4"
+    ember-cli-babel "^7.26.6"
     ember-cli-path-utils "^1.0.0"
-    ember-cli-typescript "^4.0.0"
-    heimdalljs "^0.3.0"
+    ember-cli-typescript "^4.1.0"
 
 "@ember-decorators/component@^6.1.1":
   version "6.1.1"
@@ -1260,14 +1260,6 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/ordered-set@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@ember/ordered-set/-/ordered-set-4.0.0.tgz#c5ec021ab8d4734c6db92708a81edd499d45fd31"
-  integrity sha512-cUCcme4R5H37HyK8w0qzdG5+lpb3XVr2RQHLyWEP4JsKI66Ob4tizoJOs8rb/XdHCv+F5WeA321hfPMi3DrZbg==
-  dependencies:
-    ember-cli-babel "^7.22.1"
-    ember-compatibility-helpers "^1.1.1"
-
 "@ember/render-modifiers@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz#2e87c48db49d922ce4850d707215caaac60d8444"
@@ -1285,12 +1277,12 @@
     ember-cli-babel "^7.26.11"
     ember-modifier-manager-polyfill "^1.2.0"
 
-"@ember/string@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ember/string/-/string-1.1.0.tgz#58ec0e8867e94d3bcdcde7aa7a9fe06d450079e8"
-  integrity sha512-T8UHFSO9hrkRM9+OingBmbQ69mdb8xjEXxZLCNprQX+cEJI+dyI0Nv3JAYt/0SFTT+/IQW40r004O2n/CsNnEQ==
+"@ember/string@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.0.0.tgz#e3a3cc7874c9f64eadfdac644d8b1238721ce289"
+  integrity sha512-T+7QYDp8ItlQseNveK2lL6OsOO5wg7aNQ/M2RpO8cGwM80oZOnr/Y35HmMfu4ejFEc+F1LPegvu7LGfeJOicWA==
   dependencies:
-    ember-cli-babel "^7.4.0"
+    ember-cli-babel "^7.26.6"
 
 "@ember/test-helpers@^2.2.0":
   version "2.6.0"
@@ -1314,7 +1306,7 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
-"@embroider/macros@0.41.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1", "@embroider/macros@^1.0.0":
+"@embroider/macros@1.6.0", "@embroider/macros@^0.41.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1", "@embroider/macros@^1.0.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.5.0.tgz#8c67666359e7814d91cdeac2fd96c896080473b3"
   integrity sha512-QqNsWmIJ8LvwWg+YAfB+nfcRZ49hAJNTJAKt2IDpgZDKa/FYj/Mp75UWfJ1BJvB3KUq50OQCOv4TZ3ZcU9h/TQ==
@@ -1341,12 +1333,12 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0", "@embroider/util@^0.41.0":
-  version "0.41.0"
-  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-0.41.0.tgz#5324cb4742aa4ed8d613c4f88a466f73e4e6acc1"
-  integrity sha512-ytA3J/YfQh7FEUEBwz3ezTqQNm/S5et5rZw3INBIy4Ak4x0NXV/VXLjyL8mv3txL8fGknZTBdXEhDsHUKIq8SQ==
+"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0", "@embroider/util@^0.41.0", "@embroider/util@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.6.0.tgz#6a817dfd5192afaab41e80ebce623d5812b30985"
+  integrity sha512-oUQDAMiAATHsiNwEMH/SzNSQ/Z5wDr9f6NImsDIFLvDT6T34/p7cqR4wyfrfMRtcc1EB6PbwhZ6bXYsJ6QPWRA==
   dependencies:
-    "@embroider/macros" "0.41.0"
+    "@embroider/macros" "1.6.0"
     broccoli-funnel "^3.0.5"
     ember-cli-babel "^7.23.1"
 
@@ -1553,10 +1545,12 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/broccoli-plugin@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#38f8462fecaebc4e09a32e4d4ed1b9808f75bbca"
-  integrity sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ==
+"@types/broccoli-plugin@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz#290fda2270c47a568edfd0cefab8bb840d8bb7b2"
+  integrity sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==
+  dependencies:
+    broccoli-plugin "*"
 
 "@types/chai-as-promised@^7.1.2":
   version "7.1.5"
@@ -2020,7 +2014,7 @@ acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.0, acorn@^7.4.0:
+acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -3451,6 +3445,19 @@ broccoli-persistent-filter@^3.1.2:
     symlink-or-copy "^1.0.1"
     sync-disk-cache "^2.0.0"
 
+broccoli-plugin@*, broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.5, broccoli-plugin@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
+  integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
+  dependencies:
+    broccoli-node-api "^1.7.0"
+    broccoli-output-wrapper "^3.2.5"
+    fs-merger "^3.2.1"
+    promise-map-series "^0.3.0"
+    quick-temp "^0.1.8"
+    rimraf "^3.0.2"
+    symlink-or-copy "^1.3.1"
+
 broccoli-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz#73e2cfa05f8ea1e3fc1420c40c3d9e7dc724bf02"
@@ -3471,7 +3478,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^2.0.0, broccoli-plugin@^2.1.0:
+broccoli-plugin@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
   integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
@@ -3494,33 +3501,20 @@ broccoli-plugin@^3.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.5, broccoli-plugin@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
-  integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
+broccoli-rollup@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-5.0.0.tgz#a77b53bcef1b70e988913fee82265c0a4ca530da"
+  integrity sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==
   dependencies:
-    broccoli-node-api "^1.7.0"
-    broccoli-output-wrapper "^3.2.5"
-    fs-merger "^3.2.1"
-    promise-map-series "^0.3.0"
-    quick-temp "^0.1.8"
-    rimraf "^3.0.2"
-    symlink-or-copy "^1.3.1"
-
-broccoli-rollup@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz#7531a24d88ddab9f1bace1c6ee6e6ca74a38d36f"
-  integrity sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==
-  dependencies:
-    "@types/broccoli-plugin" "^1.3.0"
-    broccoli-plugin "^2.0.0"
+    "@types/broccoli-plugin" "^3.0.0"
+    broccoli-plugin "^4.0.7"
     fs-tree-diff "^2.0.1"
     heimdalljs "^0.2.6"
     node-modules-path "^1.0.1"
-    rollup "^1.12.0"
+    rollup "^2.50.0"
     rollup-pluginutils "^2.8.1"
     symlink-or-copy "^1.2.0"
-    walk-sync "^1.1.3"
+    walk-sync "^2.2.0"
 
 broccoli-sass-source-maps@^4.0.0:
   version "4.0.0"
@@ -5093,7 +5087,7 @@ ember-bootstrap@4.9.0:
     silent-error "^1.0.1"
     tracked-toolbox "^1.2.3"
 
-ember-cache-primitive-polyfill@^1.0.0:
+ember-cache-primitive-polyfill@^1.0.0, ember-cache-primitive-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz#a27075443bd87e5af286c1cd8a7df24e3b9f6715"
   integrity sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==
@@ -5102,6 +5096,16 @@ ember-cache-primitive-polyfill@^1.0.0:
     ember-cli-version-checker "^5.1.1"
     ember-compatibility-helpers "^1.2.1"
     silent-error "^1.1.1"
+
+ember-cached-decorator-polyfill@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.4.tgz#f1e2c65cc78d0d9c4ac0e047e643af477eb85ace"
+  integrity sha512-JOK7kBCWsTVCzmCefK4nr9BACDJk0owt9oIUaVt6Q0UtQ4XeAHmoK5kQ/YtDcxQF1ZevHQFdGhsTR3JLaHNJgA==
+  dependencies:
+    "@glimmer/tracking" "^1.0.4"
+    ember-cache-primitive-polyfill "^1.0.1"
+    ember-cli-babel "^7.21.0"
+    ember-cli-babel-plugin-helpers "^1.1.1"
 
 ember-cli-app-version@^3.1.3:
   version "3.2.0"
@@ -5124,7 +5128,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-"ember-cli-babel@> 7.0.0", ember-cli-babel@^5.1.5, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.12.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.4.0, ember-cli-babel@^7.7.3:
+"ember-cli-babel@> 7.0.0", ember-cli-babel@^5.1.5, ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.12.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -5512,7 +5516,7 @@ ember-cli-typescript@^3.1.3:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
-ember-cli-typescript@^4.0.0:
+ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
   integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
@@ -5528,7 +5532,7 @@ ember-cli-typescript@^4.0.0:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
@@ -5683,7 +5687,7 @@ ember-code-snippet@^3.0.0:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
   integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
@@ -5705,25 +5709,24 @@ ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-co
     ember-compatibility-helpers "^1.2.0"
     ember-destroyable-polyfill "^2.0.2"
 
-ember-data@~3.25.0:
-  version "3.25.0"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.25.0.tgz#fe9bbff26563aa61dfc4430f61c16141e5d57d30"
-  integrity sha512-qz2ZvMJuMMLrANLks/mbPvCejydNR96INRXAZ+0MlvABj1jhogQRZIXaKbD/6NnHj8O/I+XLXHn6zENP/oDRww==
+ember-data@~3.28.0:
+  version "3.28.9"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.28.9.tgz#7b7812082d40047905946e99cef05847c650833c"
+  integrity sha512-J4ANZ49xu+fp10EH/9P00OtvBA6qdomk16MAZYFyp3NNTTMpEXFXa4AKCdN80l+Jl8LcR9YHzh16zOZLl9k/zw==
   dependencies:
-    "@ember-data/adapter" "3.25.0"
-    "@ember-data/debug" "3.25.0"
-    "@ember-data/model" "3.25.0"
-    "@ember-data/private-build-infra" "3.25.0"
-    "@ember-data/record-data" "3.25.0"
-    "@ember-data/serializer" "3.25.0"
-    "@ember-data/store" "3.25.0"
+    "@ember-data/adapter" "3.28.9"
+    "@ember-data/debug" "3.28.9"
+    "@ember-data/model" "3.28.9"
+    "@ember-data/private-build-infra" "3.28.9"
+    "@ember-data/record-data" "3.28.9"
+    "@ember-data/serializer" "3.28.9"
+    "@ember-data/store" "3.28.9"
     "@ember/edition-utils" "^1.2.0"
-    "@ember/ordered-set" "^4.0.0"
-    "@ember/string" "^1.0.0"
+    "@ember/string" "^3.0.0"
     "@glimmer/env" "^0.1.7"
     broccoli-merge-trees "^4.2.0"
-    ember-cli-babel "^7.18.0"
-    ember-cli-typescript "^4.0.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-typescript "^4.1.0"
     ember-inflector "^4.0.1"
 
 ember-decorators@^6.1.0:
@@ -6071,13 +6074,14 @@ ember-template-recast@^5.0.1:
     tmp "^0.2.1"
     workerpool "^6.1.4"
 
-ember-test-selectors@^0.3.8:
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-0.3.9.tgz#dbe0a815cf04cad83c555f232cd69f50e95b342a"
-  integrity sha1-2+CoFc8Eytg8VV8jLNafUOlbNCo=
+ember-test-selectors@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz#ba9bb19550d9dec6e4037d86d2b13c2cfd329341"
+  integrity sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==
   dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^2.0.0"
+    calculate-cache-key-for-tree "^2.0.0"
+    ember-cli-babel "^7.26.4"
+    ember-cli-version-checker "^5.1.2"
 
 ember-truth-helpers@2.0.0:
   version "2.0.0"
@@ -8034,13 +8038,6 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5, heim
   dependencies:
     rsvp "~3.2.1"
 
-heimdalljs@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.3.3.tgz#e92d2c6f77fd46d5bf50b610d28ad31755054d0b"
-  integrity sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=
-  dependencies:
-    rsvp "~3.2.1"
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -8239,12 +8236,7 @@ infer-owner@^1.0.3:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-inflection@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
-  integrity sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=
-
-inflection@^1.12.0:
+inflection@^1.12.0, inflection@~1.13.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.2.tgz#15e8c797c6c3dadf31aa658f8df8a4ea024798b0"
   integrity sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==
@@ -12109,14 +12101,12 @@ rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.12.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
+rollup@^2.50.0:
+  version "2.70.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
+  integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rsvp@3.0.14:
   version "3.0.14"


### PR DESCRIPTION
- Mostly involves updating dev deps, especially `ember-data`
- Fixes template-related deprecations in test that hadn't been caught by ember-template-lint
- Excludes `ember-global` for reasons [explained here](https://github.com/qonto/ember-cp-validations/pull/13#issuecomment-1102524899)
- This is the last release compatible with <3.28