### PR TITLE
Remove volatile support & enable Ember 4 tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
   rules: {
     'ember/no-classic-classes': 'off',
     'ember/no-new-mixins': 'off',
-    'ember/no-volatile-computed-properties': 'off',
   },
   overrides: [
     // node files

--- a/addon/index.js
+++ b/addon/index.js
@@ -242,10 +242,10 @@ import Validator from './validations/validator';
  *     disabled: Ember.computed.not('model.meta.username.isEnabled'),
  *     min: Ember.computed.readOnly('model.meta.username.minLength'),
  *     max: Ember.computed.readOnly('model.meta.username.maxLength'),
- *     description: Ember.computed(function() {
+ *     description: Ember.computed('model', 'attribute', function() {
  *       // CPs have access to the `model` and `attribute`
  *       return this.get('model').generateDescription(this.get('attribute'));
- *     }).volatile() // Disable caching and force recompute on every get call
+ *     })
  *   })
  * });
  * ```

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -26,7 +26,6 @@ import {
   isDsModel,
   isValidatable,
   isPromise,
-  mergeOptions,
 } from '../utils/utils';
 import {
   VALIDATIONS_CLASS,
@@ -410,10 +409,7 @@ function createAttrsClass(validatableAttributes, validationRules, model) {
  * @return {Ember.ComputedProperty} A computed property which is a ResultCollection
  */
 function createCPValidationFor(attribute, model, validations) {
-  let isVolatile = hasOption(validations, 'volatile', true);
-  let dependentKeys = isVolatile
-    ? []
-    : getCPDependentKeysFor(attribute, model, validations);
+  let dependentKeys = getCPDependentKeysFor(attribute, model, validations);
 
   let cp = computed(
     ...dependentKeys,
@@ -442,35 +438,7 @@ function createCPValidationFor(attribute, model, validations) {
     })
   ).readOnly();
 
-  if (isVolatile) {
-    cp = cp.volatile();
-  }
-
   return cp;
-}
-
-/**
- * Check if a collection of validations have an option
- * equal to the given value
- *
- * @method hasOption
- * @private
- * @param {Array} validations
- * @param {String} option
- * @param {Boolean} [value=true]
- * @returns {Boolean}
- */
-function hasOption(validations, option, value = true) {
-  for (let i = 0; i < validations.length; i++) {
-    let { options, defaultOptions = {}, globalOptions = {} } = validations[i];
-    let mergedOptions = mergeOptions(options, defaultOptions, globalOptions);
-
-    if (mergedOptions[option] === value) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 /**

--- a/addon/validations/validator.js
+++ b/addon/validations/validator.js
@@ -117,26 +117,6 @@ import { deprecate } from '@ember/debug';
  * })
  * ```
  *
- * ### volatile
- *
- * Default: __false__
- *
- * If any validator sets the volatile option to **true** (including options, default options, and global options),
- * it will place the entire attribute's CP in a volatile state. This means that it will set it into non-cached mode.
- * When in this mode the computed property will not automatically cache the return value.
- *
- * Dependency keys have no effect on volatile properties as they are for cache invalidation and notification when
- * cached value is invalidated. Any changes to the dependents will not refire validations.
- *
- * __**WARNING: This option should only be used if you know what you're doing**__
- *
- * ```javascript
- * // Examples
- * validator('length', {
- *   volatile: true
- * })
- * ```
- *
  * ### value
  *
  * Used to retrieve the value to validate. This will overwrite the validator's default `value` method.

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -16,7 +16,6 @@ module.exports = async function () {
       },
       {
         name: 'ember-release',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
@@ -26,10 +25,10 @@ module.exports = async function () {
       },
       {
         name: 'ember-beta',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            'ember-data': '^4.1.0',
           },
         },
       },
@@ -39,6 +38,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-data': '^4.1.0',
           },
         },
       },

--- a/tests/dummy/app/models/user-detail.js
+++ b/tests/dummy/app/models/user-detail.js
@@ -1,6 +1,4 @@
 // BEGIN-SNIPPET user-detail-model
-import { computed } from '@ember/object';
-
 import Model, { attr } from '@ember-data/model';
 import moment from 'moment';
 import { validator, buildValidations } from 'ember-cp-validations';
@@ -14,9 +12,9 @@ const Validations = buildValidations(
       validators: [
         validator('presence', true),
         validator('date', {
-          after: computed(function () {
+          get after() {
             return moment().subtract(120, 'years').format('M/D/YYYY');
-          }).volatile(),
+          },
           format: 'M/D/YYYY',
           message(type, value /*, context */) {
             if (type === 'before') {

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -8,7 +8,7 @@ self.deprecationWorkflow.config = {
       handler: 'throw',
       matchId: 'deprecated-run-loop-and-computed-dot-access',
     },
-    { handler: 'silence', matchId: 'computed-property.volatile' },
+    { handler: 'throw', matchId: 'computed-property.volatile' },
     { handler: 'throw', matchId: 'this-property-fallback' },
   ],
 };


### PR DESCRIPTION
- 💥 Breaking: Removes volatile support from CPs, as it's no longer supported in Ember 4
- Enables Ember 4 tests, because the above is no longer a blocker (Note: Canary is still allowed to fail)