### PR TITLE
Ensure Ember Data 4.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         try-scenario:
           - ember-lts-3.28
           - ember-release
+          - ember-release-with-ember-data-4.4
           - ember-beta
           - ember-canary
           - ember-default-with-jquery

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -24,6 +24,15 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-release-with-ember-data-4.4',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release'),
+            'ember-data': '~4.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-beta',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Ember Data has breaking changes starting 4.5 in its internals we rely on. To ensure backwards compatibility in future ember-cp-validations releases, this adds the last compatible version to the test suite. The default release channel (and upwards) are failing because their Ember Data versions resolve to ~4.8 I think.