### PR TITLE
Fix tests for ember-data@^4.5

### DIFF
--- a/tests/dummy/app/serializers/application.js
+++ b/tests/dummy/app/serializers/application.js
@@ -1,0 +1,3 @@
+import RESTSerializer from '@ember-data/serializer/rest';
+
+export default class ApplicationSerializer extends RESTSerializer {}

--- a/tests/integration/validations/model-relationships-test.js
+++ b/tests/integration/validations/model-relationships-test.js
@@ -1,9 +1,14 @@
+// We should not be using `import DS from 'ember-data'`, but this is pretty much
+// how we can solve imports of `PromiseArray` & `PromiseObject` for both below
+// 4.5 and above.
+//
+// eslint-disable-next-line ember/use-ember-data-rfc-395-imports
+import DS from 'ember-data';
 import { Promise as EmberPromise } from 'rsvp';
 import ArrayProxy from '@ember/array/proxy';
 import EmberObject from '@ember/object';
 import { isNone } from '@ember/utils';
 import { A as emberArray } from '@ember/array';
-import { PromiseArray, PromiseObject } from '@ember-data/store/-private';
 import setupObject from '../../helpers/setup-object';
 import DefaultMessages from 'dummy/validators/messages';
 import BelongsToValidator from 'ember-cp-validations/validators/belongs-to';
@@ -13,6 +18,8 @@ import PresenceValidator from 'ember-cp-validations/validators/presence';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+
+const { PromiseArray, PromiseObject } = DS;
 
 const Validators = {
   presence(value, options, model, attr) {

--- a/tests/unit/validations/nested-model-relationship-test.js
+++ b/tests/unit/validations/nested-model-relationship-test.js
@@ -390,53 +390,52 @@ module('Unit | Validations | Nested Model Relationships', function (hooks) {
 
   test('order with invalid question shows valid if invalid question is deleted in reverse order', function (assert) {
     assert.expect(9);
-    let order = run(() =>
-      this.owner
-        .lookup('service:store')
-        .createRecord('order', { id: 1, source: 'external' })
-    );
-
-    let orderLine,
-      orderSelection,
-      orderSelectionQuestion,
-      orderSelectionQuestion2;
-
     let store = this.owner.lookup('service:store');
-    run(() => {
-      let fakeSave = function (model) {
-        model.get('_internalModel').adapterWillCommit();
-        model.get('_internalModel').adapterDidCommit();
-      };
 
-      orderLine = store.createRecord('order-line', {
+    let payload = {
+      order: {
         id: 1,
-        order,
+        source: 'external',
+      },
+      orderLine: {
+        id: 1,
+        order: 1,
         type: 'item',
-      });
-      orderSelection = store.createRecord('order-selection', {
+      },
+      orderSelection: {
         id: 1,
-        order,
-        line: orderLine,
+        order: 1,
+        line: 1,
         quantity: 1,
-      });
-      orderSelectionQuestion = store.createRecord('order-selection-question', {
-        id: 1,
-        order,
-        selection: orderSelection,
-        text: 'answer',
-      });
-      orderSelectionQuestion2 = store.createRecord('order-selection-question', {
-        id: 2,
-        order,
-        selection: orderSelection,
-      });
+      },
+      orderSelectionQuestions: [
+        {
+          id: 1,
+          order: 1,
+          selection: 1,
+          text: 'answer',
+        },
+        {
+          id: 2,
+          order: 1,
+          selection: 1,
+        },
+      ],
+    };
 
-      fakeSave(order);
-      fakeSave(orderLine);
-      fakeSave(orderSelection);
-      fakeSave(orderSelectionQuestion);
-      fakeSave(orderSelectionQuestion2);
-    });
+    store.pushPayload(payload);
+
+    let order = store.peekRecord('order', 1);
+    let orderLine = store.peekRecord('order-line', 1);
+    let orderSelection = store.peekRecord('order-selection', 1);
+    let orderSelectionQuestion = store.peekRecord(
+      'order-selection-question',
+      1
+    );
+    let orderSelectionQuestion2 = store.peekRecord(
+      'order-selection-question',
+      2
+    );
 
     assert.equal(order.get('lines.length'), 1, 'Order has 1 Order Line');
     assert.equal(

--- a/tests/unit/validators/ds-error-test.js
+++ b/tests/unit/validators/ds-error-test.js
@@ -1,21 +1,30 @@
-import EmberObject from '@ember/object';
-import { Errors } from '@ember-data/model/-private';
+import Store from '@ember-data/store';
+import Model, { attr } from '@ember-data/model';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-let model, validator, message;
+let model, validator, message, store;
 
 module('Unit | Validator | ds-error', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
+    this.owner.register(
+      'model:user',
+      class extends Model {
+        @attr('string') username;
+      }
+    );
+
+    this.owner.register('service:store', Store);
+    store = this.owner.lookup('service:store');
     validator = this.owner.lookup('validator:ds-error');
   });
 
   test('works with empty object', function (assert) {
     assert.expect(1);
 
-    model = EmberObject.create();
+    model = store.createRecord('user');
 
     message = validator.validate(undefined, undefined, model, 'username');
     assert.equal(message, true);
@@ -24,10 +33,7 @@ module('Unit | Validator | ds-error', function (hooks) {
   test('it works', function (assert) {
     assert.expect(2);
 
-    model = EmberObject.create({
-      errors: Errors.create(),
-      username: null,
-    });
+    model = store.createRecord('user');
 
     message = validator.validate(undefined, undefined, model, 'username');
     assert.equal(message, true);
@@ -41,10 +47,7 @@ module('Unit | Validator | ds-error', function (hooks) {
   test('gets last message', function (assert) {
     assert.expect(2);
 
-    model = EmberObject.create({
-      errors: Errors.create(),
-      username: null,
-    });
+    model = store.createRecord('user');
 
     message = validator.validate(undefined, undefined, model, 'username');
     assert.equal(message, true);


### PR DESCRIPTION
Fixes tests that relied on the `Errors` internals (`@ember-data/model/-private`)

- [x] `Errors.create()`
- [x] `import { PromiseArray, PromiseObject } from '@ember-data/store/-private'`
- [x] `_internalModel.adapterWillCommit/adapterDidCommit`
